### PR TITLE
Moving configurations from script file to config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.log
 .current_coin
 .current_coin_table
+*.pyc
+__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .current_coin_table
 *.pyc
 __pycache__
+config.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.log
+.current_coin
+.current_coin_table

--- a/README.md
+++ b/README.md
@@ -20,19 +20,8 @@ The bot jumps between a configured set of coins on condition that it does not re
 * [Create a Binance account.](https://www.binance.com/hw_register.html)
 * Enable Two-factor Authentication.
 * Create a new API key.
-* Plug the API key and API secret key into the script. 
-  ```
-  #Add API key here
-  api_key = ''
-  #Add API secret key here
-  api_secret_key = ''
-  ```
-* Get a cryptocurrncy. if its symobl is not in the default list, add it. 
-* Fill in your cryptocurrency symbol.
-  ```
-  #Pass the symbol of the currently held coin here when running script for the first time
-  g_state = CryptoState('')
-  ```
+* Get a cryptocurrency. if its symbol is not in the default list, add it. 
+* Run the script once, and enter your API key, secret key and cryptocurrency symbol when prompted (a list of supported symbols is available in the script).
 
 ## Requirements
 `pip install python-binance`

--- a/configman.py
+++ b/configman.py
@@ -1,53 +1,52 @@
 # Globals
 g_config_file = "config.txt"
 
-g_cfg_field_api_key = "api_key"
-g_cfg_field_api_secret = "api_secret_key"
+class ConfigMan():
 
-g_config_fields = [g_cfg_field_api_key, g_cfg_field_api_secret]
+    cfg_field_api_key = "api_key"
+    cfg_field_api_secret = "api_secret_key"
+    cfg_field_current_coin = "current_coin"
 
-def _generate_new_config_file():
-    # Generate a new config file
-    print("Generating new 'config.txt' file.")
+    cfg_fields = [cfg_field_api_key, cfg_field_api_secret, cfg_field_current_coin]
 
-    values = {}
-    for field in g_config_fields:
-        val = input("{}: ".format(field)).strip()
-        values[field] = val
+    def __init__(self):
+        # read config file
+        try:
+            with open(g_config_file, "r") as cf:
+                config_lines = cf.readlines()
+
+            values = {}
+            for cl in config_lines:
+                key, val = [s.strip() for s in cl.split("=")]
+                values[key] = val
+            
+            self.config_values = values
+        except:
+            # if file doesn't exist
+            values = self._generate_new_config_file()
+            self.config_values = values
+
+    def get_api_keys(self):
+        return self.config_values[self.cfg_field_api_key], self.config_values[self.cfg_field_api_secret]
     
-    config_lines = [k + "=" + v + "\n" for k,v in values.items()]
+    def get_current_coin(self):
+        return self.config_values[self.cfg_field_current_coin]
 
-    with open(g_config_file, "w") as cf:
-        cf.writelines(config_lines)
+    def _generate_new_config_file(self):
+        # Generate a new config file
+        print("Generating new 'config.txt' file.")
 
-    return values
+        values = {}
+        for field in self.cfg_fields:
+            val = input("{}: ".format(field)).strip()
+            values[field] = val
+        
+        config_lines = [k + "=" + v + "\n" for k,v in values.items()]
 
+        with open(g_config_file, "w") as cf:
+            cf.writelines(config_lines)
 
-def get_api_keys():
-    # parse the file and return public, private keys
-    try:
-        with open(g_config_file, "r") as cf:
-            config_lines = cf.readlines()
-    except:
-        # if we couldn't find the config file, generate a new one through user input
-        print("'config.txt' doesn't exist...")
-        config_vals = _generate_new_config_file()
-        return config_vals[g_cfg_field_api_key], config_vals[g_cfg_field_api_secret]
-
-    # look for api_key
-
-    api_key_line = list(filter(lambda s: s.find(g_cfg_field_api_key) != -1, config_lines))[0]
-    api_key = api_key_line.split("=")[1].strip()
-
-    # look for secret key
-    api_secret_key_line = list(filter(lambda s: s.find(g_cfg_field_api_secret) != -1, config_lines))[0]
-    api_secret_key = api_secret_key_line.split("=")[1].strip()
-
-    # sanity
-    if not api_secret_key or not api_key:
-        raise("No api keys found in config.txt!")
-
-    return api_key, api_secret_key
+        return values
 
 # should be imported...
 def main():

--- a/configman.py
+++ b/configman.py
@@ -1,0 +1,57 @@
+# Globals
+g_config_file = "config.txt"
+
+g_cfg_field_api_key = "api_key"
+g_cfg_field_api_secret = "api_secret_key"
+
+g_config_fields = [g_cfg_field_api_key, g_cfg_field_api_secret]
+
+def _generate_new_config_file():
+    # Generate a new config file
+    print("Generating new 'config.txt' file.")
+
+    values = {}
+    for field in g_config_fields:
+        val = input("{}: ".format(field)).strip()
+        values[field] = val
+    
+    config_lines = [k + "=" + v + "\n" for k,v in values.items()]
+
+    with open(g_config_file, "w") as cf:
+        cf.writelines(config_lines)
+
+    return values
+
+
+def get_api_keys():
+    # parse the file and return public, private keys
+    try:
+        with open(g_config_file, "r") as cf:
+            config_lines = cf.readlines()
+    except:
+        # if we couldn't find the config file, generate a new one through user input
+        print("'config.txt' doesn't exist...")
+        config_vals = _generate_new_config_file()
+        return config_vals[g_cfg_field_api_key], config_vals[g_cfg_field_api_secret]
+
+    # look for api_key
+
+    api_key_line = list(filter(lambda s: s.find(g_cfg_field_api_key) != -1, config_lines))[0]
+    api_key = api_key_line.split("=")[1].strip()
+
+    # look for secret key
+    api_secret_key_line = list(filter(lambda s: s.find(g_cfg_field_api_secret) != -1, config_lines))[0]
+    api_secret_key = api_secret_key_line.split("=")[1].strip()
+
+    # sanity
+    if not api_secret_key or not api_key:
+        raise("No api keys found in config.txt!")
+
+    return api_key, api_secret_key
+
+# should be imported...
+def main():
+    pass
+
+if __name__ == "__main__":
+    main()

--- a/crypto_trading.py
+++ b/crypto_trading.py
@@ -4,6 +4,8 @@ import math
 import time
 import os
 import json
+# Project imports
+import configman
 
 # Logger setup
 logger = logging.getLogger('crypto_trader_logger')
@@ -21,12 +23,14 @@ logger.info('Started')
 supported_coin_list = supported_coin_list = [u'XLM', u'XRP', u'TRX', u'ICX', u'EOS', u'IOTA', u'ONT',
                                              u'QTUM', u'ETC', u'ADA', u'XMR', u'DASH', u'NEO', u'ATOM', u'DOGE', u'VET', u'BAT', u'OMG', u'BTT']
 
+# configurations
+g_config = configman.ConfigMan()
 
 class CryptoState():
     _coin_backup_file = ".current_coin"
     _table_backup_file = ".current_coin_table"
 
-    def __init__(self, current_coin):
+    def __init__(self):
         if(os.path.isfile(self._coin_backup_file) and os.path.isfile(self._table_backup_file)):
             with open(self._coin_backup_file, "r") as backup_file:
                 coin = backup_file.read()
@@ -35,6 +39,7 @@ class CryptoState():
             self.current_coin = coin
             self.coin_table = coin_table
         else:
+            current_coin = g_config.get_current_coin()
             if (not current_coin in supported_coin_list):
                 exit(
                     "***\nERROR!\nSince there is no backup file, a proper coin name must be provided at init\n***")
@@ -53,9 +58,7 @@ class CryptoState():
         self.__dict__[name] = value
         return
 
-
-# Pass the symbol of the currently held coin here when running script for the first time
-g_state = CryptoState('')
+g_state = CryptoState()
 
 
 def retry(howmany):
@@ -240,10 +243,7 @@ def scout(client, transaction_fee=0.001, multiplier=5):
 
 
 def main():
-    # Add API key here
-    api_key = ''
-    # Add API secret key here
-    api_secret_key = ''
+    api_key, api_secret_key = g_config.get_api_keys()
 
     client = Client(api_key, api_secret_key)
 


### PR DESCRIPTION
All configurations (api keys, currrent coin) are now stored in a configuration filed (ignored by git through .gitignore). This will allow easier modification of the code, as we won't have to worry about our secret keys and other configurations making it in to the public repo somehow.