### PR TITLE
Rename requirments.txt to requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The bot jumps between a configured set of coins on the condition that it does no
 
 ### Install Python dependencies
 
-Run the following line in the terminal: `pip install -r requirments.txt`.
+Run the following line in the terminal: `pip install -r requirements.txt`.
 
 ### Create user configuration
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-binance>=0.3

--- a/requirments.txt
+++ b/requirments.txt
@@ -1,1 +1,0 @@
-python-binance>=0.3


### PR DESCRIPTION
Hi 👋,

this is a very small change, but during setup I almost went crazy because I kept typing "requirements.txt" but the file was not found because the filename was misspelled here 😄.