### PR TITLE
Initialize, update and scout ticker prices in batch - Ignore symbols in supported_coins_table not matching remote pair - Telegram log with QueueHandler (no blocking)

### DIFF
--- a/crypto_trading.py
+++ b/crypto_trading.py
@@ -344,9 +344,10 @@ def update_trade_threshold(client):
     all_tickers = get_all_market_tickers(client)
 
     global g_state
+    
     current_coin_price = get_market_ticker_price_from_list(all_tickers, g_state.current_coin + 'USDT')
 
-    if curr_coin_price is None:
+    if current_coin_price is None:
         logger.info("Skipping update... current coin {0} not found".format(g_state.current_coin + 'USDT'))
         return
 
@@ -402,9 +403,9 @@ def scout(client, transaction_fee=0.001, multiplier=5):
 
     global g_state
     
-    curr_coin_price = get_market_ticker_price_from_list(all_tickers, g_state.current_coin + 'USDT')
+    current_coin_price = get_market_ticker_price_from_list(all_tickers, g_state.current_coin + 'USDT')
     
-    if curr_coin_price is None:
+    if current_coin_price is None:
         logger.info("Skipping scouting... current coin {0} not found".format(g_state.current_coin + 'USDT'))
         return
 
@@ -416,7 +417,7 @@ def scout(client, transaction_fee=0.001, multiplier=5):
             continue
 
         # Obtain (current coin)/(optional coin)
-        coin_opt_coin_ratio = curr_coin_price / \
+        coin_opt_coin_ratio = current_coin_price / \
            optional_coin_price
 
         if (coin_opt_coin_ratio - transaction_fee * multiplier * coin_opt_coin_ratio) > g_state.coin_table[g_state.current_coin][optional_coin]:


### PR DESCRIPTION
I use get_all_tickers function to retrieve all tickers in one request and then find the ticker by symbol there.

I had to change Telegram logger to QueueHandler so it don't block until request ends when there are too many requests, in initialize_trade_thresholds for example.