### PR TITLE
Move scout parameters into the config

### DIFF
--- a/.user.cfg.example
+++ b/.user.cfg.example
@@ -7,3 +7,6 @@ botChatID=
 botToken=
 tld=com
 hourToKeepScoutHistory=1
+scout_transaction_fee=0.001
+scout_multiplier=5
+scout_sleep_time=5


### PR DESCRIPTION
I found myself playing around with the parameters for the Scouting routine so I moved them into the config to maintain the settings over time. 

- Moved the scout transaction fee and multiplier into the config and parse them
- Added new config to example config
- Added original scout configuration as defaults in case config keys are missing. 