### PR TITLE
Added support for various TLD's (i.e. 'binance.us')

### DIFF
--- a/.user.cfg.example
+++ b/.user.cfg.example
@@ -5,3 +5,4 @@ current_coin=
 bridge=USDT
 botChatID=
 botToken=
+tld=com

--- a/crypto_trading.py
+++ b/crypto_trading.py
@@ -432,8 +432,9 @@ def scout(client, transaction_fee=0.001, multiplier=5):
 def main():
     api_key = config.get(USER_CFG_SECTION, 'api_key')
     api_secret_key = config.get(USER_CFG_SECTION, 'api_secret_key')
+    tld = config.get(USER_CFG_SECTION, 'tld') or 'com' # Default Top-level domain is 'com'
 
-    client = Client(api_key, api_secret_key)
+    client = Client(api_key, api_secret_key, tld=tld)
 
     global g_state
     if not (os.path.isfile(g_state._table_backup_file)):


### PR DESCRIPTION
Base library (https://github.com/sammchardy/python-binance) supports TLD's other than '.com'. This PR adds this functionality to the user config. Especially helpful for US users, which much use 'binance.us'