### PR TITLE
Logging

### DIFF
--- a/.user.cfg.example
+++ b/.user.cfg.example
@@ -6,3 +6,4 @@ bridge=USDT
 botChatID=
 botToken=
 tld=com
+hourToKeepScoutHistory=1

--- a/crypto_trading.py
+++ b/crypto_trading.py
@@ -18,7 +18,7 @@ from binance.exceptions import BinanceAPIException
 from sqlalchemy.orm import Session
 
 from database import set_coins, set_current_coin, get_current_coin, get_pairs_from, \
-    db_session, create_database, get_pair, log_scout, TradeLog, CoinValue
+    db_session, create_database, get_pair, log_scout, TradeLog, CoinValue, prune_scout_history
 from models import Coin, Pair
 
 # Config consts
@@ -52,6 +52,9 @@ TELEGRAM_CHAT_ID = config.get(USER_CFG_SECTION, 'botChatID')
 TELEGRAM_TOKEN = config.get(USER_CFG_SECTION, 'botToken')
 BRIDGE_SYMBOL = config.get(USER_CFG_SECTION, 'bridge')
 BRIDGE = Coin(BRIDGE_SYMBOL, False)
+
+# Prune settings
+SCOUT_HISTORY_PRUNE_TIME = float(config.get(USER_CFG_SECTION, 'hourToKeepScoutHistory', fallback="1"))
 
 
 class RequestsHandler(Handler):
@@ -434,6 +437,8 @@ def scout(client: Client, transaction_fee=0.001, multiplier=5):
             current_coin, best_pair.to_coin_id))
         transaction_through_tether(
             client, best_pair)
+
+    prune_scout_history(SCOUT_HISTORY_PRUNE_TIME)
 
 
 def update_values(client: Client):

--- a/crypto_trading.py
+++ b/crypto_trading.py
@@ -10,6 +10,7 @@ import random
 import time
 import traceback
 from logging import Handler, Formatter
+from typing import Dict
 
 import requests
 from binance.client import Client
@@ -17,7 +18,7 @@ from binance.exceptions import BinanceAPIException
 from sqlalchemy.orm import Session
 
 from database import set_coins, set_current_coin, get_current_coin, get_pairs_from, \
-    db_session, create_database, get_pair, log_scout
+    db_session, create_database, get_pair, log_scout, TradeLog
 from models import Coin, Pair
 
 # Config consts
@@ -50,7 +51,7 @@ logger.addHandler(ch)
 TELEGRAM_CHAT_ID = config.get(USER_CFG_SECTION, 'botChatID')
 TELEGRAM_TOKEN = config.get(USER_CFG_SECTION, 'botToken')
 BRIDGE_SYMBOL = config.get(USER_CFG_SECTION, 'bridge')
-BRIDGE = Coin(BRIDGE_SYMBOL)
+BRIDGE = Coin(BRIDGE_SYMBOL, False)
 
 
 class RequestsHandler(Handler):
@@ -176,6 +177,7 @@ def buy_alt(client: Client, alt: Coin, crypto: Coin):
     '''
     Buy altcoin
     '''
+    trade_log = TradeLog(alt, crypto, False)
     alt_symbol = alt.symbol
     crypto_symbol = crypto.symbol
     ticks = {}
@@ -183,11 +185,14 @@ def buy_alt(client: Client, alt: Coin, crypto: Coin):
         if filt['filterType'] == 'LOT_SIZE':
             if filt['stepSize'].find('1') == 0:
                 ticks[alt_symbol] = 1 - filt['stepSize'].find('.')
-            else:    
+            else:
                 ticks[alt_symbol] = filt['stepSize'].find('1') - 1
             break
 
-    order_quantity = ((math.floor(get_currency_balance(client, crypto_symbol) *
+    alt_balance = get_currency_balance(client, alt_symbol)
+    crypto_balance = get_currency_balance(client, crypto_symbol)
+
+    order_quantity = ((math.floor(crypto_balance *
                                   10 ** ticks[alt_symbol] / get_market_ticker_price(client,
                                                                                     alt_symbol + crypto_symbol)) / float(
         10 ** ticks[alt_symbol])))
@@ -208,6 +213,8 @@ def buy_alt(client: Client, alt: Coin, crypto: Coin):
             time.sleep(1)
         except Exception as e:
             logger.info("Unexpected Error: {0}".format(e))
+
+    trade_log.set_ordered(alt_balance, crypto_balance, order_quantity)
 
     order_recorded = False
     while not order_recorded:
@@ -233,6 +240,8 @@ def buy_alt(client: Client, alt: Coin, crypto: Coin):
 
     logger.info('Bought {0}'.format(alt_symbol))
 
+    trade_log.set_complete(stat['cummulativeQuoteQty'])
+
     return order
 
 
@@ -241,6 +250,7 @@ def sell_alt(client: Client, alt: Coin, crypto: Coin):
     '''
     Sell altcoin
     '''
+    trade_log = TradeLog(alt, crypto, True)
     alt_symbol = alt.symbol
     crypto_symbol = crypto.symbol
     ticks = {}
@@ -248,7 +258,7 @@ def sell_alt(client: Client, alt: Coin, crypto: Coin):
         if filt['filterType'] == 'LOT_SIZE':
             if filt['stepSize'].find('1') == 0:
                 ticks[alt_symbol] = 1 - filt['stepSize'].find('.')
-            else:    
+            else:
                 ticks[alt_symbol] = filt['stepSize'].find('1') - 1
             break
 
@@ -256,8 +266,9 @@ def sell_alt(client: Client, alt: Coin, crypto: Coin):
                                  10 ** ticks[alt_symbol]) / float(10 ** ticks[alt_symbol]))
     logger.info('Selling {0} of {1}'.format(order_quantity, alt_symbol))
 
-    bal = get_currency_balance(client, alt_symbol)
-    logger.info('Balance is {0}'.format(bal))
+    alt_balance = get_currency_balance(client, alt_symbol)
+    crypto_balance = get_currency_balance(client, crypto_symbol)
+    logger.info('Balance is {0}'.format(alt_balance))
     order = None
     while order is None:
         order = client.order_market_sell(
@@ -267,6 +278,8 @@ def sell_alt(client: Client, alt: Coin, crypto: Coin):
 
     logger.info('order')
     logger.info(order)
+
+    trade_log.set_ordered(alt_balance, crypto_balance, order_quantity)
 
     # Binance server can take some time to save the order
     logger.info("Waiting for Binance")
@@ -298,26 +311,28 @@ def sell_alt(client: Client, alt: Coin, crypto: Coin):
             logger.info("Unexpected Error: {0}".format(e))
 
     newbal = get_currency_balance(client, alt_symbol)
-    while (newbal >= bal):
+    while (newbal >= alt_balance):
         newbal = get_currency_balance(client, alt_symbol)
 
     logger.info('Sold {0}'.format(alt_symbol))
 
+    trade_log.set_complete(stat['cummulativeQuoteQty'])
+
     return order
 
 
-def transaction_through_tether(client: Client, source_coin: Coin, dest_coin: Coin):
+def transaction_through_tether(client: Client, pair: Pair):
     '''
     Jump from the source coin to the destination coin through tether
     '''
     result = None
     while result is None:
-        result = sell_alt(client, source_coin, BRIDGE)
+        result = sell_alt(client, pair.from_coin, BRIDGE)
     result = None
     while result is None:
-        result = buy_alt(client, dest_coin, BRIDGE)
+        result = buy_alt(client, pair.to_coin, BRIDGE)
 
-    set_current_coin(dest_coin)
+    set_current_coin(pair.to_coin)
     update_trade_threshold(client)
 
 
@@ -390,8 +405,8 @@ def scout(client: Client, transaction_fee=0.001, multiplier=5):
         logger.info("Skipping scouting... current coin {0} not found".format(current_coin + BRIDGE))
         return
 
-    ratio_dict = {}
-    
+    ratio_dict: Dict[Pair, float] = {}
+
     for pair in get_pairs_from(current_coin):
         if not pair.to_coin.enabled:
             continue
@@ -407,18 +422,18 @@ def scout(client: Client, transaction_fee=0.001, multiplier=5):
         coin_opt_coin_ratio = current_coin_price / optional_coin_price
 
         # save ratio so we can pick the best option, not necessarily the first
-        ratio_dict[pair.to_coin] = (coin_opt_coin_ratio - transaction_fee * multiplier * coin_opt_coin_ratio) - pair.ratio
+        ratio_dict[pair] = (coin_opt_coin_ratio - transaction_fee * multiplier * coin_opt_coin_ratio) - pair.ratio
 
     # keep only ratios bigger than zero
-    ratio_dict = dict(filter(lambda x: x[1] > 0, ratio_dict.items()))
+    ratio_dict = {k: v for k, v in ratio_dict.items() if v > 0}
 
     # if we have any viable options, pick the one with the biggest ratio
     if ratio_dict:
-        max_optional_coin = max(ratio_dict, key=ratio_dict.get)
+        best_pair = max(ratio_dict, key=ratio_dict.get)
         logger.info('Will be jumping from {0} to {1}'.format(
-                current_coin, max_optional_coin))
+            current_coin, best_pair.to_coin_id))
         transaction_through_tether(
-                client, current_coin, max_optional_coin)
+            client, best_pair)
 
 
 def migrate_old_state():

--- a/crypto_trading.py
+++ b/crypto_trading.py
@@ -450,6 +450,15 @@ def update_values(client: Client):
             btc_value = get_market_ticker_price_from_list(all_ticker_values, coin + "BTC")
             session.add(CoinValue(coin, balance, usd_value, btc_value))
 
+            # Prune oldest entry if over limit
+            # Disabled for now but might be useful later
+            # Should add a more long term log for day to day performance
+            if False:
+                log_entries = session.query(CoinValue).filter(CoinValue.coin == coin).count()
+                if log_entries > 300_000:
+                    oldest = session.query(CoinValue).order_by(CoinValue.datetime.asc()).limit(1).first()
+                    session.delete(oldest)
+
 
 def migrate_old_state():
     if os.path.isfile('.current_coin'):

--- a/crypto_trading.py
+++ b/crypto_trading.py
@@ -442,6 +442,8 @@ def scout(client: Client, transaction_fee=0.001, multiplier=5):
 def update_values(client: Client):
     all_ticker_values = get_all_market_tickers(client)
 
+    now = datetime.datetime.now()
+
     session: Session
     with db_session() as session:
         coins: List[Coin] = session.query(Coin).all()
@@ -451,7 +453,7 @@ def update_values(client: Client):
                 continue
             usd_value = get_market_ticker_price_from_list(all_ticker_values, coin + "USDT")
             btc_value = get_market_ticker_price_from_list(all_ticker_values, coin + "BTC")
-            session.add(CoinValue(coin, balance, usd_value, btc_value))
+            session.add(CoinValue(coin, balance, usd_value, btc_value, datetime=now))
 
 
 def migrate_old_state():

--- a/crypto_trading.py
+++ b/crypto_trading.py
@@ -17,7 +17,7 @@ from binance.exceptions import BinanceAPIException
 from sqlalchemy.orm import Session
 
 from database import set_coins, set_current_coin, get_current_coin, get_pairs_from, \
-    db_session, create_database, get_pair
+    db_session, create_database, get_pair, log_scout
 from models import Coin, Pair
 
 # Config consts
@@ -400,6 +400,8 @@ def scout(client: Client, transaction_fee=0.001, multiplier=5):
         if optional_coin_price is None:
             logger.info("Skipping scouting... optional coin {0} not found".format(pair.to_coin + BRIDGE))
             continue
+
+        log_scout(pair, pair.ratio, current_coin_price, optional_coin_price)
 
         # Obtain (current coin)/(optional coin)
         coin_opt_coin_ratio = current_coin_price / optional_coin_price

--- a/crypto_trading.py
+++ b/crypto_trading.py
@@ -8,7 +8,6 @@ import os
 import queue
 import random
 import time
-import traceback
 from logging import Handler, Formatter
 from typing import List, Dict
 
@@ -20,6 +19,7 @@ from sqlalchemy.orm import Session
 from database import set_coins, set_current_coin, get_current_coin, get_pairs_from, \
     db_session, create_database, get_pair, log_scout, TradeLog, CoinValue, prune_scout_history, prune_value_history
 from models import Coin, Pair
+from scheduler import SafeScheduler
 
 # Config consts
 CFG_FL_NAME = 'user.cfg'
@@ -438,8 +438,6 @@ def scout(client: Client, transaction_fee=0.001, multiplier=5):
         transaction_through_tether(
             client, best_pair)
 
-    prune_scout_history(SCOUT_HISTORY_PRUNE_TIME)
-
 
 def update_values(client: Client):
     all_ticker_values = get_all_market_tickers(client)
@@ -517,20 +515,15 @@ def main():
             buy_alt(client, current_coin, BRIDGE)
             logger.info("Ready to start trading")
 
+    schedule = SafeScheduler(logger)
+    schedule.every(5).seconds.do(scout, client=client).tag("scouting")
+    schedule.every(1).minutes.do(update_values, client=client).tag("updating value history")
+    schedule.every(1).minutes.do(prune_scout_history, hours=SCOUT_HISTORY_PRUNE_TIME).tag("pruning scout history")
+    schedule.every(1).hours.do(prune_value_history).tag("pruning value history")
+
     while True:
-        try:
-            time.sleep(5)
-            scout(client)
-
-            # Only log values once per minute
-            if datetime.datetime.now().second < 5:
-                update_values(client)
-
-                # Prune log every hour
-                if datetime.datetime.now().minute == 0:
-                    prune_value_history()
-        except Exception as e:
-            logger.info('Error while scouting...\n{}\n'.format(traceback.format_exc()))
+        schedule.run_pending()
+        time.sleep(1)
 
 
 if __name__ == "__main__":

--- a/database.py
+++ b/database.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta
 from typing import List, Union, Optional
 
-from sqlalchemy import create_engine, and_
+from sqlalchemy import create_engine, func
 from sqlalchemy.orm import sessionmaker, scoped_session, Session
 
 from models import *
@@ -51,8 +51,7 @@ def set_coins(symbols: List[str]):
         for from_coin in coins:
             for to_coin in coins:
                 if from_coin != to_coin:
-                    pair = session.query(Pair).filter(
-                        and_(Pair.from_coin == from_coin, Pair.to_coin == to_coin)).first()
+                    pair = session.query(Pair).filter(Pair.from_coin == from_coin, Pair.to_coin == to_coin).first()
                     if pair is None:
                         session.add(Pair(from_coin, to_coin))
 
@@ -92,8 +91,7 @@ def get_pair(from_coin: Union[Coin, str], to_coin: Union[Coin, str]):
     to_coin = get_coin(to_coin)
     session: Session
     with db_session() as session:
-        pair: Pair = session.query(Pair).filter(
-            and_(Pair.from_coin == from_coin, Pair.to_coin == to_coin)).first()
+        pair: Pair = session.query(Pair).filter(Pair.from_coin == from_coin, Pair.to_coin == to_coin).first()
         session.expunge(pair)
         return pair
 
@@ -119,6 +117,45 @@ def prune_scout_history(hours: float):
     session: Session
     with db_session() as session:
         session.query(ScoutHistory).filter(ScoutHistory.datetime < time_diff).delete()
+
+
+def prune_value_history():
+    session: Session
+    with db_session() as session:
+        # Sets the first entry for each coin for each hour as 'hourly'
+        hourly_entries: List[CoinValue] = session.query(CoinValue).group_by(
+            CoinValue.coin_id, func.strftime('%H', CoinValue.datetime)).all()
+        for entry in hourly_entries:
+            entry.interval = Interval.HOURLY
+
+        # Sets the first entry for each coin for each day as 'daily'
+        daily_entries: List[CoinValue] = session.query(CoinValue).group_by(
+            CoinValue.coin_id, func.date(CoinValue.datetime)).all()
+        for entry in daily_entries:
+            entry.interval = Interval.DAILY
+
+        # Sets the first entry for each coin for each month as 'weekly' (Sunday is the start of the week)
+        weekly_entries: List[CoinValue] = session.query(CoinValue).group_by(
+            CoinValue.coin_id, func.strftime("%Y-%W", CoinValue.datetime)).all()
+        for entry in weekly_entries:
+            entry.interval = Interval.WEEKLY
+
+        # The last 24 hours worth of minutely entries will be kept, so count(coins) * 1440 entries
+        time_diff = datetime.now() - timedelta(hours=24)
+        session.query(CoinValue).filter(CoinValue.interval == Interval.MINUTELY,
+                                        CoinValue.datetime < time_diff).delete()
+
+        # The last 28 days worth of hourly entries will be kept, so count(coins) * 672 entries
+        time_diff = datetime.now() - timedelta(days=28)
+        session.query(CoinValue).filter(CoinValue.interval == Interval.HOURLY,
+                                        CoinValue.datetime < time_diff).delete()
+
+        # The last years worth of daily entries will be kept, so count(coins) * 365 entries
+        time_diff = datetime.now() - timedelta(days=365)
+        session.query(CoinValue).filter(CoinValue.interval == Interval.DAILY,
+                                        CoinValue.datetime < time_diff).delete()
+
+        # All weekly entries will be kept forever
 
 
 class TradeLog:

--- a/database.py
+++ b/database.py
@@ -105,6 +105,14 @@ def get_pairs_from(from_coin: Union[Coin, str]):
         return pairs
 
 
+def log_scout(pair: Pair, target_ratio: float, current_coin_price: float, other_coin_price: float):
+    session: Session
+    with db_session() as session:
+        pair = session.merge(pair)
+        sh = ScoutHistory(pair, target_ratio, current_coin_price, other_coin_price)
+        session.add(sh)
+
+
 def create_database():
     Base.metadata.create_all(engine)
 

--- a/database.py
+++ b/database.py
@@ -113,6 +113,32 @@ def log_scout(pair: Pair, target_ratio: float, current_coin_price: float, other_
         session.add(sh)
 
 
+class TradeLog:
+    def __init__(self, from_coin: Coin, to_coin: Coin, selling: bool):
+        session: Session
+        with db_session() as session:
+            from_coin = session.merge(from_coin)
+            to_coin = session.merge(to_coin)
+            self.trade = Trade(from_coin, to_coin, selling)
+            session.add(self.trade)
+
+    def set_ordered(self, alt_starting_balance, crypto_starting_balance, alt_trade_amount):
+        session: Session
+        with db_session() as session:
+            trade: Trade = session.merge(self.trade)
+            trade.alt_starting_balance = alt_starting_balance
+            trade.alt_trade_amount = alt_trade_amount
+            trade.crypto_starting_balance = crypto_starting_balance
+            trade.state = TradeState.ORDERED
+
+    def set_complete(self, crypto_trade_amount):
+        session: Session
+        with db_session() as session:
+            trade: Trade = session.merge(self.trade)
+            trade.crypto_trade_amount = crypto_trade_amount
+            trade.state = TradeState.COMPLETE
+
+
 def create_database():
     Base.metadata.create_all(engine)
 

--- a/database.py
+++ b/database.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from datetime import datetime, timedelta
 from typing import List, Union, Optional
 
 from sqlalchemy import create_engine, and_
@@ -111,6 +112,13 @@ def log_scout(pair: Pair, target_ratio: float, current_coin_price: float, other_
         pair = session.merge(pair)
         sh = ScoutHistory(pair, target_ratio, current_coin_price, other_coin_price)
         session.add(sh)
+
+
+def prune_scout_history(hours: float):
+    time_diff = datetime.now() - timedelta(hours=hours)
+    session: Session
+    with db_session() as session:
+        session.query(ScoutHistory).filter(ScoutHistory.datetime < time_diff).delete()
 
 
 class TradeLog:

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,6 +1,6 @@
 from .base import Base
 from .coin import Coin
-from .coin_value import CoinValue
+from .coin_value import CoinValue, Interval
 from .current_coin import CurrentCoin
 from .pair import Pair
 from .scout_history import ScoutHistory

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,5 +1,6 @@
 from .base import Base
 from .coin import Coin
+from .coin_value import CoinValue
 from .current_coin import CurrentCoin
 from .pair import Pair
 from .scout_history import ScoutHistory

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -3,4 +3,4 @@ from .coin import Coin
 from .current_coin import CurrentCoin
 from .pair import Pair
 from .scout_history import ScoutHistory
-
+from .trade import Trade, TradeState

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -2,3 +2,5 @@ from .base import Base
 from .coin import Coin
 from .current_coin import CurrentCoin
 from .pair import Pair
+from .scout_history import ScoutHistory
+

--- a/models/coin_value.py
+++ b/models/coin_value.py
@@ -1,5 +1,5 @@
-import datetime
 import enum
+from datetime import datetime as _datetime
 
 from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Float, Enum
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -30,14 +30,16 @@ class CoinValue(Base):
 
     interval = Column(Enum(Interval))
 
-    datetime = Column(DateTime, default=datetime.datetime.utcnow)
+    datetime = Column(DateTime)
 
-    def __init__(self, coin: Coin, balance: float, usd_price: float, btc_price: float, interval=Interval.MINUTELY):
+    def __init__(self, coin: Coin, balance: float, usd_price: float, btc_price: float, interval=Interval.MINUTELY,
+                 datetime: _datetime = None):
         self.coin = coin
         self.balance = balance
         self.usd_price = usd_price
         self.btc_price = btc_price
         self.interval = interval
+        self.datetime = datetime or _datetime.now()
 
     @hybrid_property
     def usd_value(self):

--- a/models/coin_value.py
+++ b/models/coin_value.py
@@ -1,11 +1,19 @@
 import datetime
+import enum
 
-from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Float
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Float, Enum
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
 
 from .base import Base
 from .coin import Coin
+
+
+class Interval(enum.Enum):
+    MINUTELY = "MINUTELY"
+    HOURLY = "HOURLY"
+    DAILY = "DAILY"
+    WEEKLY = "WEEKLY"
 
 
 class CoinValue(Base):
@@ -20,13 +28,16 @@ class CoinValue(Base):
     usd_price = Column(Float)
     btc_price = Column(Float)
 
+    interval = Column(Enum(Interval))
+
     datetime = Column(DateTime, default=datetime.datetime.utcnow)
 
-    def __init__(self, coin: Coin, balance: float, usd_price: float, btc_price: float):
+    def __init__(self, coin: Coin, balance: float, usd_price: float, btc_price: float, interval=Interval.MINUTELY):
         self.coin = coin
         self.balance = balance
         self.usd_price = usd_price
         self.btc_price = btc_price
+        self.interval = interval
 
     @hybrid_property
     def usd_value(self):

--- a/models/coin_value.py
+++ b/models/coin_value.py
@@ -1,0 +1,49 @@
+import datetime
+
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Float
+from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy.orm import relationship
+
+from .base import Base
+from .coin import Coin
+
+
+class CoinValue(Base):
+    __tablename__ = "coin_value"
+
+    id = Column(Integer, primary_key=True)
+
+    coin_id = Column(String, ForeignKey('coins.symbol'))
+    coin = relationship("Coin")
+
+    balance = Column(Float)
+    usd_price = Column(Float)
+    btc_price = Column(Float)
+
+    datetime = Column(DateTime, default=datetime.datetime.utcnow)
+
+    def __init__(self, coin: Coin, balance: float, usd_price: float, btc_price: float):
+        self.coin = coin
+        self.balance = balance
+        self.usd_price = usd_price
+        self.btc_price = btc_price
+
+    @hybrid_property
+    def usd_value(self):
+        if self.usd_price is None:
+            return None
+        return self.balance * self.usd_price
+
+    @usd_value.expression
+    def usd_value(cls):
+        return cls.balance * cls.usd_price
+
+    @hybrid_property
+    def btc_value(self):
+        if self.btc_price is None:
+            return None
+        return self.balance * self.btc_price
+
+    @btc_value.expression
+    def btc_value(cls):
+        return cls.balance * cls.btc_price

--- a/models/scout_history.py
+++ b/models/scout_history.py
@@ -1,0 +1,35 @@
+import datetime
+
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Float
+from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy.orm import relationship
+
+from .base import Base
+from .pair import Pair
+
+
+class ScoutHistory(Base):
+    __tablename__ = "scout_history"
+
+    id = Column(Integer, primary_key=True)
+    
+    pair_id = Column(String, ForeignKey('pairs.id'))
+    pair = relationship("Pair")
+
+    target_ratio = Column(Float)
+    current_coin_price = Column(Float)
+    other_coin_price = Column(Float)
+
+    datetime = Column(DateTime, default=datetime.datetime.utcnow)
+
+    def __init__(self, pair: Pair, target_ratio: float, current_coin_price: float, other_coin_price: float):
+        self.pair = pair
+        self.target_ratio = target_ratio
+        self.current_coin_price = current_coin_price
+        self.other_coin_price = other_coin_price
+
+    @hybrid_property
+    def current_ratio(self):
+        return self.current_coin_price / self.other_coin_price
+
+

--- a/models/trade.py
+++ b/models/trade.py
@@ -1,0 +1,43 @@
+import datetime
+import enum
+
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Float, Enum, Boolean
+from sqlalchemy.orm import relationship
+
+from .base import Base
+from .coin import Coin
+
+
+class TradeState(enum.Enum):
+    STARTING = "STARTING"
+    ORDERED = "ORDERED"
+    COMPLETE = "COMPLETE"
+
+
+class Trade(Base):
+    __tablename__ = "trade_history"
+
+    id = Column(Integer, primary_key=True)
+
+    alt_coin_id = Column(String, ForeignKey('coins.symbol'))
+    alt_coin = relationship("Coin", foreign_keys=[alt_coin_id], lazy='joined')
+
+    crypto_coin_id = Column(String, ForeignKey('coins.symbol'))
+    crypto_coin = relationship("Coin", foreign_keys=[crypto_coin_id], lazy='joined')
+
+    selling = Column(Boolean)
+
+    state = Column(Enum(TradeState))
+
+    alt_starting_balance = Column(Float)
+    alt_trade_amount = Column(Float)
+    crypto_starting_balance = Column(Float)
+    crypto_trade_amount = Column(Float)
+
+    datetime = Column(DateTime, default=datetime.datetime.utcnow)
+
+    def __init__(self, alt_coin: Coin, crypto_coin: Coin, selling: bool):
+        self.alt_coin = alt_coin
+        self.crypto_coin = crypto_coin
+        self.state = TradeState.STARTING
+        self.selling = selling

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 python-binance>=0.3
 sqlalchemy
+schedule

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,0 +1,32 @@
+import datetime
+import logging
+from traceback import format_exc
+
+from schedule import Scheduler, Job
+
+
+class SafeScheduler(Scheduler):
+    """
+    An implementation of Scheduler that catches jobs that fail, logs their
+    exception tracebacks as errors, and keeps going.
+
+    Use this to run jobs that may or may not crash without worrying about
+    whether other jobs will run or if they'll crash the entire script.
+    """
+
+    def __init__(self, logger: logging.Logger, rerun_immediately=True):
+        self.logger = logger
+        self.rerun_immediately = rerun_immediately
+
+        super().__init__()
+
+    def _run_job(self, job: Job):
+        try:
+            super()._run_job(job)
+        except Exception:
+            self.logger.error(f"Error while {next(iter(job.tags))}...\n{format_exc()}")
+            job.last_run = datetime.datetime.now()
+            if not self.rerun_immediately:
+                # Reschedule the job for the next time it was meant to run, instead of letting it run
+                # next tick
+                job._schedule_next_run()


### PR DESCRIPTION
This depends on #93 

Adds database tables to log trading, scouting and value histories.

I'm definitely open to changing what we log based on suggestions, or adding more tables. 

* Trade history
  * Logs each individual trade, so a trade from VIM to ETH would make two log entries, VIM->USDT and USDT->ETH
  * Stores the starting value of the two coins, and the amount traded, so we can easily infer the end value
* Scouting history
  * Logs for each pair we check during scouting, so that you can keep track of which coin it's getting close to switching to
  * Stores the pair, the ratio we're aiming for, the current coin price and the other coin price. Current ratio can then be inferred from the two prices
  * This creates `count(coins) - 1` log entries every 5 seconds, which if left could obviously start to use a fair amount of storage, so a method of pruning old entries will be a must. I haven't implemented this yet
* Value history
  * Logs the value of each enabled coin
  * Stores the coin, your current balance (if balance is zero, an entry is not made), the price of the coin in btc and the price of the coin in usd
    * I know the purpose of the bot isn't to maximise value but I think keeping track of this will be valuable to a lot of people
  * This will also need to be pruned, but probably not as aggressively as scouting history. We still want to preserve this history even if we don't have it at 5 second granularity. Maybe we don't even need to be logging it every 5 seconds. Maybe we have a second table for daily value logs. Maybe when we prune this table we leave one log entry for each coin per day. I don't know!