### PR TITLE
Don't keep attempting transaction if the amount is invalid

### DIFF
--- a/crypto_trading.py
+++ b/crypto_trading.py
@@ -238,6 +238,9 @@ def buy_alt(client: Client, alt: Coin, crypto: Coin):
             order_recorded = True
         except BinanceAPIException as e:
             logger.info(e)
+            if e.code == -1013:
+                logger.info(f"Can't execute transaction: {order_quantity} is an invalid amount")
+                return None
             time.sleep(10)
         except Exception as e:
             logger.info("Unexpected Error: {0}".format(e))
@@ -285,10 +288,16 @@ def sell_alt(client: Client, alt: Coin, crypto: Coin):
     logger.info('Balance is {0}'.format(alt_balance))
     order = None
     while order is None:
-        order = client.order_market_sell(
-            symbol=alt_symbol + crypto_symbol,
-            quantity=(order_quantity)
-        )
+        try:
+            order = client.order_market_sell(
+                symbol=alt_symbol + crypto_symbol,
+                quantity=order_quantity
+            )
+        except BinanceAPIException as e:
+            logger.info(e)
+            if e.code == -1013:
+                logger.info(f"Can't execute transaction: {order_quantity} is an invalid amount")
+                return None
 
     logger.info('order')
     logger.info(order)


### PR DESCRIPTION
I feel like eventually we should remove the big retries and handle as many types of errors individually

Maybe we should have a check in the scouting code to see if we actually have enough of the current coin. I was thinking of adding a method that would check through all the coins you have enabled and switch to the one with the biggest bridge coin value in the scenario where you don't have enough of the current coin. This could also be how we set the initial coin if the user doesn't specify it, instead of selecting one randomly. 

Kind of fixes #75