### PR TITLE
Empty lines and trailing spaces removal 

### DIFF
--- a/crypto_trading.py
+++ b/crypto_trading.py
@@ -54,7 +54,8 @@ supported_coin_list = []
 
 # Get supported coin list from supported_coin_list file
 with open('supported_coin_list') as f:
-    supported_coin_list = f.read().upper().splitlines()
+    supported_coin_list = f.read().upper().strip().splitlines()
+    supported_coin_list = list(filter(None, supported_coin_list))
 
 def retry(howmany):
     def tryIt(func):


### PR DESCRIPTION
Fix for recently observed bug which causes 'USDTUSDT' pair. Trailing spaces are stripped and every empty string is removed from the list of coins.