### PR TITLE
Submit Buy Order Quicker by Removing Redundant API Requests

### DIFF
--- a/binance_api_manager.py
+++ b/binance_api_manager.py
@@ -95,7 +95,7 @@ class BinanceAPIManager:
                 order = self.BinanceClient.order_limit_buy(
                     symbol=alt_symbol + crypto_symbol,
                     quantity=order_quantity,
-                    price=self.from_coin_price,
+                    price=from_coin_price,
                 )
                 self.logger.info(order)
             except BinanceAPIException as e:

--- a/binance_api_manager.py
+++ b/binance_api_manager.py
@@ -35,13 +35,13 @@ class BinanceAPIManager:
                 return float(currency_balance[u"free"])
         return None
 
-    def first(iterable, condition=lambda x: True):
+    def first(self, iterable, condition=lambda x: True):
         try:
             return next(x for x in iterable if condition(x))
         except StopIteration:
             return None
 
-    def get_market_ticker_price_from_list(all_tickers, ticker_symbol):
+    def get_market_ticker_price_from_list(self, all_tickers, ticker_symbol):
         '''
         Get ticker price of a specific coin
         '''

--- a/binance_api_manager.py
+++ b/binance_api_manager.py
@@ -35,12 +35,17 @@ class BinanceAPIManager:
                 return float(currency_balance[u"free"])
         return None
 
+    def first(iterable, condition=lambda x: True):
+        try:
+            return next(x for x in iterable if condition(x))
+        except StopIteration:
+            return None
 
     def get_market_ticker_price_from_list(all_tickers, ticker_symbol):
         '''
         Get ticker price of a specific coin
         '''
-        ticker = first(all_tickers, condition=lambda x: x[u'symbol'] == ticker_symbol)
+        ticker = self.first(all_tickers, condition=lambda x: x[u'symbol'] == ticker_symbol)
         return float(ticker[u'price']) if ticker else None
 
     def retry(self, func, *args, **kwargs):

--- a/binance_api_manager.py
+++ b/binance_api_manager.py
@@ -35,6 +35,14 @@ class BinanceAPIManager:
                 return float(currency_balance[u"free"])
         return None
 
+
+    def get_market_ticker_price_from_list(all_tickers, ticker_symbol):
+        '''
+        Get ticker price of a specific coin
+        '''
+        ticker = first(all_tickers, condition=lambda x: x[u'symbol'] == ticker_symbol)
+        return float(ticker[u'price']) if ticker else None
+
     def retry(self, func, *args, **kwargs):
         time.sleep(1)
         attempts = 0
@@ -71,7 +79,7 @@ class BinanceAPIManager:
 
         alt_balance = self.get_currency_balance(alt_symbol)
         crypto_balance = self.get_currency_balance(crypto_symbol)
-        from_coin_price = get_market_ticker_price_from_list(all_tickers, alt_symbol + crypto_symbol)
+        from_coin_price = self.get_market_ticker_price_from_list(all_tickers, alt_symbol + crypto_symbol)
 
         order_quantity = math.floor(
             crypto_balance

--- a/binance_api_manager.py
+++ b/binance_api_manager.py
@@ -48,10 +48,10 @@ class BinanceAPIManager:
                 attempts += 1
         return None
 
-    def buy_alt(self, alt: Coin, crypto: Coin):
-        return self.retry(self._buy_alt, alt, crypto)
+    def buy_alt(self, alt: Coin, crypto: Coin, all_tickers):
+        return self.retry(self._buy_alt, alt, crypto, all_tickers)
 
-    def _buy_alt(self, alt: Coin, crypto: Coin):
+    def _buy_alt(self, alt: Coin, crypto: Coin, all_tickers):
         """
         Buy altcoin
         """
@@ -71,11 +71,12 @@ class BinanceAPIManager:
 
         alt_balance = self.get_currency_balance(alt_symbol)
         crypto_balance = self.get_currency_balance(crypto_symbol)
+        from_coin_price = get_market_ticker_price_from_list(all_tickers, alt_symbol + crypto_symbol)
 
         order_quantity = math.floor(
             crypto_balance
             * 10 ** ticks[alt_symbol]
-            / self.get_market_ticker_price(alt_symbol + crypto_symbol)
+            / from_coin_price
         ) / float(10 ** ticks[alt_symbol])
         self.logger.info("BUY QTY {0}".format(order_quantity))
 
@@ -86,7 +87,7 @@ class BinanceAPIManager:
                 order = self.BinanceClient.order_limit_buy(
                     symbol=alt_symbol + crypto_symbol,
                     quantity=order_quantity,
-                    price=self.get_market_ticker_price(alt_symbol + crypto_symbol),
+                    price=self.from_coin_price,
                 )
                 self.logger.info(order)
             except BinanceAPIException as e:

--- a/crypto_trading.py
+++ b/crypto_trading.py
@@ -67,7 +67,7 @@ def get_market_ticker_price_from_list(all_tickers, ticker_symbol):
     ticker = first(all_tickers, condition=lambda x: x[u'symbol'] == ticker_symbol)
     return float(ticker[u'price']) if ticker else None
 
-def transaction_through_tether(client: BinanceAPIManager, pair: Pair):
+def transaction_through_tether(client: BinanceAPIManager, pair: Pair, all_tickers):
     '''
     Jump from the source coin to the destination coin through tether
     '''
@@ -77,22 +77,18 @@ def transaction_through_tether(client: BinanceAPIManager, pair: Pair):
     # This isn't pretty, but at the moment we don't have implemented logic to escape from a bridge coin... This'll do for now
     result = None
     while result is None:
-        result = client.buy_alt(pair.to_coin, BRIDGE)
+        result = client.buy_alt(pair.to_coin, BRIDGE, all_tickers)
 
     set_current_coin(pair.to_coin)
-    update_trade_threshold(client)
+    update_trade_threshold(client, float(result[u'price']), all_tickers)
 
 
-def update_trade_threshold(client: BinanceAPIManager):
+def update_trade_threshold(client: BinanceAPIManager, current_coin_price:float, all_tickers):
     '''
     Update all the coins with the threshold of buying the current held coin
     '''
 
-    all_tickers = client.get_all_market_tickers()
-
     current_coin = get_current_coin()
-
-    current_coin_price = get_market_ticker_price_from_list(all_tickers, current_coin + BRIDGE)
 
     if current_coin_price is None:
         logger.info("Skipping update... current coin {0} not found".format(current_coin + BRIDGE))
@@ -180,7 +176,7 @@ def scout(client: BinanceAPIManager, transaction_fee=0.001, multiplier=5):
         logger.info('Will be jumping from {0} to {1}'.format(
             current_coin, best_pair.to_coin_id))
         transaction_through_tether(
-            client, best_pair)
+            client, best_pair, all_tickers)
 
 
 def update_values(client: BinanceAPIManager):
@@ -257,7 +253,8 @@ def main():
         if config.get(USER_CFG_SECTION, 'current_coin') == '':
             current_coin = get_current_coin()
             logger.info("Purchasing {0} to begin trading".format(current_coin))
-            client.buy_alt(current_coin, BRIDGE)
+            all_tickers = client.get_all_market_tickers()
+            client.buy_alt(current_coin, BRIDGE, all_tickers)
             logger.info("Ready to start trading")
 
     schedule = SafeScheduler(logger)


### PR DESCRIPTION
Base a trade on a single pull of ticker information. Re-querying the API added latency and if the price increased between the queries the actual quantity traded could be lower than the previous holding