### PR TITLE
👷‍♂️ Github Actions: Initial Implementation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
           push: true
           tags: ${{ github.repository }}:latest
       - name: Image digest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ github.repository }}:latest
       - name: Image digest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,27 @@
+name: binance-trade-bot
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ github.repository }}:latest
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,20 @@
-FROM python:3.8 as base
-
-FROM base as builder
-
-RUN mkdir /install
+FROM --platform=$BUILDPLATFORM python:3.8 as builder
 
 WORKDIR /install
 
 COPY requirements.txt /requirements.txt
 
-RUN pip install --prefix=/install -r /requirements.txt
+RUN apt-get update && apt-get install -y curl && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
+    . /root/.cargo/env && \
+    rustup toolchain install 1.41.0 && \
+    pip install --prefix=/install -r /requirements.txt
 
-FROM base
-
-COPY --from=builder /install /usr/local
-
-COPY . /app
+FROM python:3.8-slim
 
 WORKDIR /app
+
+COPY --from=builder /install /usr/local
+COPY . .
+
+CMD [ "python", "crypto_trading.py" ]


### PR DESCRIPTION
### Added
- Basic actions setup to build docker image and pushes it to dockerhub (if `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` are provided as repository secrets).

#### Supported platforms
- `linux/amd64`
- `linux/arm64`
- `linux/arm/v6`
- `linux/arm/v7`

### Why?
Would allow users to just pull the latest image instead of having to clone the git repo and build from scratch. Also paves the way for potential future linting at CI level since a lot of different people are contributing at the moment with potential different coding styles (#95).