### PR TITLE
🐳 Docker: Cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-FROM python:3.8 as base
-
-FROM base as builder
-
-RUN mkdir /install
+FROM python:3.8 as builder
 
 WORKDIR /install
 
@@ -10,10 +6,10 @@ COPY requirements.txt /requirements.txt
 
 RUN pip install --prefix=/install -r /requirements.txt
 
-FROM base
-
-COPY --from=builder /install /usr/local
-
-COPY . /app
+FROM python:3.8-slim
 
 WORKDIR /app
+
+COPY --from=builder /install /usr/local
+COPY . .
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,3 +13,4 @@ WORKDIR /app
 COPY --from=builder /install /usr/local
 COPY . .
 
+CMD [ "python", "crypto_trading.py" ]


### PR DESCRIPTION
### Fixed
- Don't remove default `CMD` from Dockerfile to prevent breaking older versions of trade bot. You can override it if you want by passing a different command...

### Changed
- Using `python:3.8-slim` as base image to reduce image size
- Cleaned up general Dockerfile for better readability