### PR TITLE
Display on the console during scout, the current coin+Bridge

### DIFF
--- a/crypto_trading.py
+++ b/crypto_trading.py
@@ -141,6 +141,8 @@ def scout(client: BinanceAPIManager, transaction_fee=0.001, multiplier=5):
     all_tickers = client.get_all_market_tickers()
 
     current_coin = get_current_coin()
+    #Display on the console, the current coin+Bridge, so users can see *some* activity and not thinkg the bot has stopped. Not logging though to reduce log size.
+    print( str( datetime.datetime.now() ) + " - CONSOLE - INFO - I am scouting the best trades. Current coin: {0} ".format( current_coin + BRIDGE ))
 
     current_coin_price = get_market_ticker_price_from_list(all_tickers, current_coin + BRIDGE)
 

--- a/crypto_trading.py
+++ b/crypto_trading.py
@@ -142,7 +142,7 @@ def scout(client: BinanceAPIManager, transaction_fee=0.001, multiplier=5):
 
     current_coin = get_current_coin()
     #Display on the console, the current coin+Bridge, so users can see *some* activity and not thinkg the bot has stopped. Not logging though to reduce log size.
-    print( str( datetime.datetime.now() ) + " - CONSOLE - INFO - I am scouting the best trades. Current coin: {0} ".format( current_coin + BRIDGE ))
+    print( str( datetime.datetime.now() ) + " - CONSOLE - INFO - I am scouting the best trades. Current coin: {0} ".format( current_coin + BRIDGE ) , end='\r')
 
     current_coin_price = get_market_ticker_price_from_list(all_tickers, current_coin + BRIDGE)
 


### PR DESCRIPTION
Display simple current coin and bridge coin whilst in the scouting function. This should give some new users (and old) bot activity and not think the bot has stopped. Note: This is not be added to the log, purely a simple print to the terminal.

