### PR TITLE
Remove "Initializing X vs Y" notifications

### DIFF
--- a/binance_trade_bot/auto_trader.py
+++ b/binance_trade_bot/auto_trader.py
@@ -66,7 +66,7 @@ class AutoTrader:
             for pair in session.query(Pair).filter(Pair.ratio == None).all():
                 if not pair.from_coin.enabled or not pair.to_coin.enabled:
                     continue
-                self.logger.info("Initializing {0} vs {1}".format(pair.from_coin, pair.to_coin))
+                self.logger.info("Initializing {0} vs {1}".format(pair.from_coin, pair.to_coin), False)
 
                 from_coin_price = get_market_ticker_price_from_list(all_tickers, pair.from_coin + self.config.BRIDGE)
                 if from_coin_price is None:

--- a/binance_trade_bot/logger.py
+++ b/binance_trade_bot/logger.py
@@ -46,14 +46,14 @@ class Logger:
         if notification and self.NotificationHandler.enabled:
             self.NotificationHandler.send_notification(message)
 
-    def info(self, message):
-        self.log(message, "info")
+    def info(self, message, notification=True):
+        self.log(message, "info", notification)
 
-    def warning(self, message):
-        self.log(message, "warning")
+    def warning(self, message, notification=True):
+        self.log(message, "warning", notification)
 
-    def error(self, message):
-        self.log(message, "error")
+    def error(self, message, notification=True):
+        self.log(message, "error", notification)
 
-    def debug(self, message):
-        self.log(message, "debug")
+    def debug(self, message, notification=True):
+        self.log(message, "debug", notification)


### PR DESCRIPTION
These notifications are breaking the rate limits of some webhooks (e.g. Discord) which results in delayed notifications.