### PR TITLE
Display the spot balance after sold coin

### DIFF
--- a/binance_api_manager.py
+++ b/binance_api_manager.py
@@ -193,6 +193,8 @@ class BinanceAPIManager:
 
         self.logger.info("Sold {0}".format(origin_symbol))
 
+        self.logger.info("Spot Balance is {0}".format(stat["cummulativeQuoteQty"]))
+
         trade_log.set_complete(stat["cummulativeQuoteQty"])
 
         return order


### PR DESCRIPTION
So that user can know the current spot balance in the message, and can clearly know whether it is losing money


![image](https://user-images.githubusercontent.com/20951677/109577232-3d2df200-7b30-11eb-9706-5320a401f60c.png)

