### PR TITLE
🐳 Docker: Point to official image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,7 @@ version: "3"
 
 services:
   crypto-trading:
-    build: .
-    image: binance_trader
+    image: edeng23/binance-trade-bot
     container_name: binance_trader
     volumes:
       - ./user.cfg:/app/user.cfg
@@ -12,15 +11,15 @@ services:
     command: python -m binance_trade_bot
 
   api:
-    depends_on:
-      - crypto-trading
-    image: binance_trader
+    image: edeng23/binance-trade-bot
     container_name: binance_trader_api
     volumes:
       - ./data:/app/data
     ports:
       - 5123:5123
     command: gunicorn api_server:app -k eventlet -w 1 --threads 1 -b 0.0.0.0:5123
+    depends_on:
+      - crypto-trading
 
   sqlitebrowser:
     image: ghcr.io/linuxserver/sqlitebrowser


### PR DESCRIPTION
### Changed
- `docker-compose.yml` example should use official image from now on