### PR TITLE
Use thread to write scout log

### DIFF
--- a/binance_trade_bot/auto_trader.py
+++ b/binance_trade_bot/auto_trader.py
@@ -1,4 +1,5 @@
 import random
+import threading
 from datetime import datetime
 from typing import Dict, List
 
@@ -132,7 +133,8 @@ class AutoTrader:
                 self.logger.info("Skipping scouting... optional coin {0} not found".format(pair.to_coin + self.config.BRIDGE))
                 continue
 
-            self.db.log_scout(pair, pair.ratio, current_coin_price, optional_coin_price)
+            thread = threading.Thread(group=None, target=self.db.log_scout, name=None, args=(pair, pair.ratio, current_coin_price, optional_coin_price))
+            thread.start()
 
             # Obtain (current coin)/(optional coin)
             coin_opt_coin_ratio = current_coin_price / optional_coin_price

--- a/binance_trade_bot/database.py
+++ b/binance_trade_bot/database.py
@@ -19,7 +19,7 @@ class Database:
     def __init__(self, logger: Logger, config: Config, uri="sqlite:///data/crypto_trading.db"):
         self.logger = logger
         self.config = config
-        self.engine = create_engine(uri)
+        self.engine = create_engine(uri, connect_args={"check_same_thread": False})
         self.SessionMaker = sessionmaker(bind=self.engine)
         self.socketio_client = Client()
 


### PR DESCRIPTION
Now the bot takes much time to calculate the pair ratio which makes the market price is out of date when processing the transaction. The issue comes from the write scout log function. This PR to reduce the delay time.

Before
```
2021-03-07 14:49:40,024 - crypto_trader_logger - INFO - Starting calculate ratio coin: MBLUSDT 
2021-03-07 14:49:40,028 - crypto_trader_logger - INFO - optional_coin_price: <BTT>: 0.00125
2021-03-07 14:49:45,049 - crypto_trader_logger - INFO - optional_coin_price: <HOT>: 0.0030834
2021-03-07 14:49:50,074 - crypto_trader_logger - INFO - optional_coin_price: <WIN>: 0.0002113
2021-03-07 14:49:55,094 - crypto_trader_logger - INFO - optional_coin_price: <NPXS>: 0.0020162
2021-03-07 14:50:00,121 - crypto_trader_logger - INFO - optional_coin_price: <DENT>: 0.0016939
2021-03-07 14:50:05,140 - crypto_trader_logger - INFO - optional_coin_price: <KEY>: 0.007369
2021-03-07 14:50:10,159 - crypto_trader_logger - INFO - optional_coin_price: <TROY>: 0.00896
2021-03-07 14:50:15,193 - crypto_trader_logger - INFO - optional_coin_price: <DREP>: 0.008951
2021-03-07 14:50:20,212 - crypto_trader_logger - INFO - optional_coin_price: <VTHO>: 0.005925
2021-03-07 14:50:25,229 - crypto_trader_logger - INFO - Finish calculate ratio
```

After
```
2021-03-07 15:11:21,178 - crypto_trader_logger - INFO - Starting calculate ratio coin: MBLUSDT 
2021-03-07 15:11:21,182 - crypto_trader_logger - INFO - optional_coin_price: <BTT>: 0.0012462
2021-03-07 15:11:21,184 - crypto_trader_logger - INFO - optional_coin_price: <HOT>: 0.0030711
2021-03-07 15:11:21,186 - crypto_trader_logger - INFO - optional_coin_price: <WIN>: 0.00021253
2021-03-07 15:11:21,190 - crypto_trader_logger - INFO - optional_coin_price: <NPXS>: 0.0020233
2021-03-07 15:11:21,193 - crypto_trader_logger - INFO - optional_coin_price: <DENT>: 0.0017131
2021-03-07 15:11:21,196 - crypto_trader_logger - INFO - optional_coin_price: <KEY>: 0.007383
2021-03-07 15:11:21,203 - crypto_trader_logger - INFO - optional_coin_price: <TROY>: 0.0091297
2021-03-07 15:11:21,207 - crypto_trader_logger - INFO - optional_coin_price: <DREP>: 0.009249
2021-03-07 15:11:21,214 - crypto_trader_logger - INFO - optional_coin_price: <VTHO>: 0.005793
2021-03-07 15:11:21,221 - crypto_trader_logger - INFO - Finish calculate ratio
```