### PR TITLE
Configurable heartbeat message with variables

### DIFF
--- a/.user.cfg.example
+++ b/.user.cfg.example
@@ -8,3 +8,5 @@ hourToKeepScoutHistory=1
 scout_transaction_fee=0.001
 scout_multiplier=5
 scout_sleep_time=5
+heartbeat_duration=0
+heartbeat_message=Scouting. Current coin: {current_coin} - Balance: {balance}. Current ratios: \n{ratios}

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Create a .cfg file named `user.cfg` based off `.user.cfg.example`, then add your
 -   **hourToKeepScoutHistory** - Controls how many hours of scouting values are kept in the database. After the amount of time specified has passed, the information will be deleted.
 -   **scout_transaction_fee** - The transaction fee percentage. This value should be changed, for example, if you are [using BNB to pay for fees](https://www.binance.com/en/support/faq/115000583311-Using-BNB-to-Pay-for-Fees).
 -   **scout_multiplier** - Controls the value by which the difference between the current state of coin ratios and previous state of ratios is multiplied. For bigger values, the bot will wait for bigger margins to arrive before making a trade.
--   **heartbeat_duration** - The time in seconds until the heartbeat message is sent. If 0, the heartbeat message won't be used. If 3600, the heartbeat message will be sent every hour.
--   **heartbeat_message** - The message to be sent everything heartbeat_duration seconds. Configurable with variables. Possible variables are:
+-   **heartbeat_duration** - The time in minutes until the heartbeat message is sent. If 0, the heartbeat message won't be used. If 60, the heartbeat message will be sent every hour.
+-   **heartbeat_message** - The message to be sent everything heartbeat_duration minutes. Configurable with variables. Possible variables are:
     -   **current_coin**: Displays the current coin's symbol.
     -   **balance**: Displays the balance of the current coin.
     -   **ratios**: Displays the ratios in percentage for each pair with the current coin.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ Create a .cfg file named `user.cfg` based off `.user.cfg.example`, then add your
 -   **hourToKeepScoutHistory** - Controls how many hours of scouting values are kept in the database. After the amount of time specified has passed, the information will be deleted.
 -   **scout_transaction_fee** - The transaction fee percentage. This value should be changed, for example, if you are [using BNB to pay for fees](https://www.binance.com/en/support/faq/115000583311-Using-BNB-to-Pay-for-Fees).
 -   **scout_multiplier** - Controls the value by which the difference between the current state of coin ratios and previous state of ratios is multiplied. For bigger values, the bot will wait for bigger margins to arrive before making a trade.
+-   **heartbeat_duration** - The time in seconds until the heartbeat message is sent. If 0, the heartbeat message won't be used. If 3600, the heartbeat message will be sent every hour.
+-   **heartbeat_message** - The message to be sent everything heartbeat_duration seconds. Configurable with variables. Possible variables are:
+    -   **current_coin**: Displays the current coin's symbol.
+    -   **balance**: Displays the balance of the current coin.
+    -   **ratios**: Displays the ratios in percentage for each pair with the current coin.
 
 #### Environment Variables
 
@@ -72,6 +77,8 @@ SCOUT_TRANSACTION_FEE: 0.001
 SCOUT_MULTIPLIER: 5
 SCOUT_SLEEP_TIME: 5
 TLD: com
+HEARTBEAT_DURATION: 0
+HEARTBEAT_MESSAGE: "Scouting. Current coin: {current_coin} - Balance: {balance}. Current ratios: \n{ratios}"
 ```
 
 ### Notifications with Apprise

--- a/binance_trade_bot/config.py
+++ b/binance_trade_bot/config.py
@@ -19,6 +19,8 @@ class Config:
             "scout_sleep_time": "5",
             "hourToKeepScoutHistory": "1",
             "tld": "com",
+            "heartbeat_duration": "0",
+            "heartbeat_message": "",
         }
 
         if not os.path.exists(CFG_FL_NAME):
@@ -52,6 +54,17 @@ class Config:
             os.environ.get("SCOUT_SLEEP_TIME")
             or config.get(USER_CFG_SECTION, "scout_sleep_time")
         )
+
+        # Get config for heartbeat
+        self.HEARTBEAT_DURATION = int(
+            os.environ.get("HEARTBEAT_DURATION")
+            or config.get(USER_CFG_SECTION, "heartbeat_duration")
+        )
+
+        self.HEARTBEAT_MESSAGE = (
+            os.environ.get("HEARTBEAT_MESSAGE")
+            or config.get(USER_CFG_SECTION, "heartbeat_message")
+        ).replace('\\n', '\n')
 
         # Get config for binance
         self.BINANCE_API_KEY = os.environ.get("API_KEY") or config.get(

--- a/binance_trade_bot/crypto_trading.py
+++ b/binance_trade_bot/crypto_trading.py
@@ -32,6 +32,8 @@ def main():
     schedule.every(1).minutes.do(trader.update_values).tag("updating value history")
     schedule.every(1).minutes.do(db.prune_scout_history).tag("pruning scout history")
     schedule.every(1).hours.do(db.prune_value_history).tag("pruning value history")
+    if config.HEARTBEAT_DURATION > 0:
+        schedule.every(config.HEARTBEAT_DURATION).seconds.do(trader.heartbeat_message).tag("heartbeat")
 
     while True:
         schedule.run_pending()

--- a/binance_trade_bot/crypto_trading.py
+++ b/binance_trade_bot/crypto_trading.py
@@ -33,7 +33,7 @@ def main():
     schedule.every(1).minutes.do(db.prune_scout_history).tag("pruning scout history")
     schedule.every(1).hours.do(db.prune_value_history).tag("pruning value history")
     if config.HEARTBEAT_DURATION > 0:
-        schedule.every(config.HEARTBEAT_DURATION).seconds.do(trader.heartbeat_message).tag("heartbeat")
+        schedule.every(config.HEARTBEAT_DURATION).minutes.do(trader.heartbeat_message).tag("heartbeat")
 
     while True:
         schedule.run_pending()


### PR DESCRIPTION
Second PR for this as I messed up the last one.
This adds a heartbeat message with a configurable message that is sent every set amount of time (in seconds).
The message uses variables that can show different informations.
It includes the following variables:

- current_coin : Displays the current coin's symbol.
- balance: Displays the balance of the current coin.
- ratios: Displays the ratios in percentage for each pair with the current coin. With the default settings, the bot should switch coins when one of the pairs shows 0.5%. (hard to explain for me but see output below)

With this example heartbeat message: "Scouting. Current coin: {current_coin} - Balance: {balance}. Current ratios: \n{ratios}"
It will log this for example:

```
Scouting. Current coin: ETH - Balance: 0.0246. Current ratios: 
ETH to XLM. Diff: -0.23%
ETH to TRX. Diff: -0.63%
ETH to ICX. Diff: -0.79%
ETH to EOS. Diff: -0.54%
ETH to IOTA. Diff: -0.85%
ETH to ONT. Diff: -0.53%
```

If you have any other variable ideas that could be added I can add them.