### PR TITLE
Update trading logic to support cancel timeout order

### DIFF
--- a/.user.cfg.example
+++ b/.user.cfg.example
@@ -8,3 +8,5 @@ hourToKeepScoutHistory=1
 scout_multiplier=5
 scout_sleep_time=5
 strategy=default
+buy_timeout=0
+sell_timeout=0

--- a/binance_trade_bot/binance_api_manager.py
+++ b/binance_trade_bot/binance_api_manager.py
@@ -30,6 +30,7 @@ class BinanceAPIManager:
         )
         self.db = db
         self.logger = logger
+        self.config = config
 
     @cached(cache=TTLCache(maxsize=1, ttl=43200))
     def get_trade_fees(self) -> Dict[str, float]:
@@ -134,6 +135,34 @@ class BinanceAPIManager:
         while order_status["status"] != "FILLED":
             try:
                 order_status = self.binance_client.get_order(symbol=origin_symbol + target_symbol, orderId=order_id)
+
+                if self._should_cancel_order(order_status):
+                    cancel_order = None
+                    while cancel_order is None:
+                        cancel_order = self.binance_client.cancel_order(
+                            symbol=origin_symbol + target_symbol, orderId=order_id
+                        )
+                    self.logger.info("Order timeout, canceled...")
+
+                    # sell partially
+                    if order_status["status"] == "PARTIALLY_FILLED" and order_status["side"] == "BUY":
+                        self.logger.info("Sell partially filled amount")
+
+                        order_quantity = self._sell_quantity(origin_symbol, target_symbol)
+                        partially_order = None
+                        while partially_order is None:
+                            partially_order = self.binance_client.order_market_sell(
+                                symbol=origin_symbol + target_symbol, quantity=order_quantity
+                            )
+
+                    self.logger.info("Going back to scouting mode...")
+                    return None
+
+                if order_status["status"] == "CANCELED":
+                    self.logger.info("Order is canceled, going back to scouting mode...")
+                    return None
+
+                time.sleep(1)
             except BinanceAPIException as e:
                 self.logger.info(e)
                 time.sleep(1)
@@ -142,6 +171,29 @@ class BinanceAPIManager:
                 time.sleep(1)
 
         return order_status
+
+    def _should_cancel_order(self, order_status):
+        minutes = (time.time() - order_status["time"] / 1000) / 60
+        timeout = 0
+
+        if order_status["side"] == "SELL":
+            timeout = float(self.config.SELL_TIMEOUT)
+        else:
+            timeout = float(self.config.BUY_TIMEOUT)
+
+        if timeout and minutes > timeout and order_status["status"] == "NEW":
+            return True
+
+        if timeout and minutes > timeout and order_status["status"] == "PARTIALLY_FILLED":
+            if order_status["side"] == "SELL":
+                return True
+
+            if order_status["side"] == "BUY":
+                current_price = self.get_market_ticker_price(order_status["symbol"])
+                if float(current_price) * (1 - 0.001) > float(order_status["price"]):
+                    return True
+
+        return False
 
     def buy_alt(self, origin_coin: Coin, target_coin: Coin, all_tickers: AllTickers):
         return self.retry(self._buy_alt, origin_coin, target_coin, all_tickers)
@@ -190,14 +242,16 @@ class BinanceAPIManager:
 
         stat = self.wait_for_order(origin_symbol, target_symbol, order["orderId"])
 
-        self.logger.info(f"Bought {origin_symbol}")
+        if stat is None:
+            return None
 
+        self.logger.info(f"Bought {origin_symbol}")
         trade_log.set_complete(stat["cummulativeQuoteQty"])
 
         return order
 
-    def sell_alt(self, origin_coin: Coin, target_coin: Coin):
-        return self.retry(self._sell_alt, origin_coin, target_coin)
+    def sell_alt(self, origin_coin: Coin, target_coin: Coin, all_tickers: AllTickers):
+        return self.retry(self._sell_alt, origin_coin, target_coin, all_tickers)
 
     def _sell_quantity(self, origin_symbol: str, target_symbol: str, origin_balance: float = None):
         origin_balance = origin_balance or self.get_currency_balance(origin_symbol)
@@ -205,7 +259,7 @@ class BinanceAPIManager:
         origin_tick = self.get_alt_tick(origin_symbol, target_symbol)
         return math.floor(origin_balance * 10 ** origin_tick) / float(10 ** origin_tick)
 
-    def _sell_alt(self, origin_coin: Coin, target_coin: Coin):
+    def _sell_alt(self, origin_coin: Coin, target_coin: Coin, all_tickers: AllTickers):
         """
         Sell altcoin
         """
@@ -215,6 +269,7 @@ class BinanceAPIManager:
 
         origin_balance = self.get_currency_balance(origin_symbol)
         target_balance = self.get_currency_balance(target_symbol)
+        from_coin_price = all_tickers.get_price(origin_symbol + target_symbol)
 
         order_quantity = self._sell_quantity(origin_symbol, target_symbol, origin_balance)
         self.logger.info(f"Selling {order_quantity} of {origin_symbol}")
@@ -222,7 +277,10 @@ class BinanceAPIManager:
         self.logger.info(f"Balance is {origin_balance}")
         order = None
         while order is None:
-            order = self.binance_client.order_market_sell(symbol=origin_symbol + target_symbol, quantity=order_quantity)
+            # Should sell at calculated price to avoid lost coin
+            order = self.binance_client.order_limit_sell(
+                symbol=origin_symbol + target_symbol, quantity=(order_quantity), price=from_coin_price
+            )
 
         self.logger.info("order")
         self.logger.info(order)
@@ -233,6 +291,9 @@ class BinanceAPIManager:
         self.logger.info("Waiting for Binance")
 
         stat = self.wait_for_order(origin_symbol, target_symbol, order["orderId"])
+
+        if stat is None:
+            return None
 
         new_balance = self.get_currency_balance(origin_symbol)
         while new_balance >= origin_balance:

--- a/binance_trade_bot/config.py
+++ b/binance_trade_bot/config.py
@@ -8,7 +8,7 @@ CFG_FL_NAME = "user.cfg"
 USER_CFG_SECTION = "binance_user_config"
 
 
-class Config:  # pylint: disable=too-few-public-methods
+class Config:  # pylint: disable=too-few-public-methods,too-many-instance-attributes
     def __init__(self):
         # Init config
         config = configparser.ConfigParser()
@@ -19,6 +19,8 @@ class Config:  # pylint: disable=too-few-public-methods
             "hourToKeepScoutHistory": "1",
             "tld": "com",
             "strategy": "default",
+            "sell_timeout": "0",
+            "buy_timeout": "0",
         }
 
         if not os.path.exists(CFG_FL_NAME):
@@ -65,3 +67,6 @@ class Config:  # pylint: disable=too-few-public-methods
         self.CURRENT_COIN_SYMBOL = os.environ.get("CURRENT_COIN_SYMBOL") or config.get(USER_CFG_SECTION, "current_coin")
 
         self.STRATEGY = os.environ.get("STRATEGY") or config.get(USER_CFG_SECTION, "strategy")
+
+        self.SELL_TIMEOUT = os.environ.get("SELL_TIMEOUT") or config.get(USER_CFG_SECTION, "sell_timeout")
+        self.BUY_TIMEOUT = os.environ.get("BUY_TIMEOUT") or config.get(USER_CFG_SECTION, "buy_timeout")

--- a/binance_trade_bot/strategies/default_strategy.py
+++ b/binance_trade_bot/strategies/default_strategy.py
@@ -3,18 +3,12 @@ import sys
 from datetime import datetime
 
 from binance_trade_bot.auto_trader import AutoTrader
-from binance_trade_bot.models import Pair
 
 
 class Strategy(AutoTrader):
     def initialize(self):
         super().initialize()
         self.initialize_current_coin()
-
-    def transaction_through_bridge(self, pair: Pair, all_tickers):
-        super().transaction_through_bridge(pair, all_tickers)
-
-        self.db.set_current_coin(pair.to_coin)
 
     def scout(self):
         """
@@ -38,7 +32,6 @@ class Strategy(AutoTrader):
             return
 
         self._jump_to_best_coin(current_coin, current_coin_price, all_tickers)
-        self.bridge_scout()
 
     def bridge_scout(self):
         current_coin = self.db.get_current_coin()

--- a/binance_trade_bot/strategies/multiple_coins_strategy.py
+++ b/binance_trade_bot/strategies/multiple_coins_strategy.py
@@ -26,5 +26,3 @@ class Strategy(AutoTrader):
             self.logger.info(f"Scouting for best trades. Current ticker: {coin + self.config.BRIDGE} ", False)
 
             self._jump_to_best_coin(coin, coin_price, all_tickers)
-
-        self.bridge_scout()

--- a/binance_trade_bot/strategies/multiple_coins_strategy.py
+++ b/binance_trade_bot/strategies/multiple_coins_strategy.py
@@ -7,6 +7,14 @@ class Strategy(AutoTrader):
         Scout for potential jumps from the current coin to another coin
         """
         all_tickers = self.manager.get_all_market_tickers()
+        have_coin = False
+
+        # last coin bought
+        current_coin = self.db.get_current_coin()
+        current_coin_symbol = ""
+
+        if current_coin is not None:
+            current_coin_symbol = current_coin.symbol
 
         for coin in self.db.get_coins():
             current_coin_balance = self.manager.get_currency_balance(coin.symbol)
@@ -16,13 +24,18 @@ class Strategy(AutoTrader):
                 self.logger.info("Skipping scouting... current coin {} not found".format(coin + self.config.BRIDGE))
                 continue
 
-            if coin_price * current_coin_balance < self.manager.get_min_notional(
-                coin.symbol, self.config.BRIDGE.symbol
-            ):
+            min_notional = self.manager.get_min_notional(coin.symbol, self.config.BRIDGE.symbol)
+
+            if coin.symbol != current_coin_symbol and coin_price * current_coin_balance < min_notional:
                 continue
+
+            have_coin = True
 
             # Display on the console, the current coin+Bridge, so users can see *some* activity and not think the bot
             # has stopped. Not logging though to reduce log size.
             self.logger.info(f"Scouting for best trades. Current ticker: {coin + self.config.BRIDGE} ", False)
 
             self._jump_to_best_coin(coin, coin_price, all_tickers)
+
+        if not have_coin:
+            self.bridge_scout()


### PR DESCRIPTION
Features:
- [x] Sell at calculated price instead of market price to avoid losing the coin
- [x] Handle cancel sell/buy order when timeout and have no filled
- [x] Handle cancel sell.buy order when timeout and partially filled

Update:
- Remove `bridge_scout` which makes the bot buy another coin after canceling the sell order. It will make you lost the coin