### PR TITLE
Add initial implementation of websockets for getting all mark prices

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,9 +6,9 @@ repos:
   hooks:
   - id: check-merge-conflict      # Check for files that contain merge conflict strings.
   - id: trailing-whitespace       # Trims trailing whitespace.
-    args: ['--markdown-linebreak-ext=md']
+    args: [--markdown-linebreak-ext=md]
   - id: mixed-line-ending         # Replaces or checks mixed line ending.
-    args: ['--fix=lf']
+    args: [--fix=lf]
   - id: end-of-file-fixer         # Makes sure files end in a newline and only a newline.
   - id: check-merge-conflict      # Check for files that contain merge conflict strings.
   - id: check-ast                 # Simply check whether files parse as valid python.
@@ -26,25 +26,25 @@ repos:
   hooks:
   - id: pyupgrade
     name: Rewrite Code to be Py3.6+
-    args: ['--py36-plus']
+    args: [--py36-plus]
 
 - repo: https://github.com/pycqa/isort
   rev: 5.6.3
   hooks:
-    - id: isort
-      args: ['--profile', 'black', '--line-length', '120']
+  - id: isort
+    args: [--profile, black, --line-length, '120']
 
 - repo: https://github.com/psf/black
   rev: 20.8b1
   hooks:
   - id: black
-    args: ['-l', '120']
+    args: [-l, '120']
 
 - repo: https://github.com/asottile/blacken-docs
   rev: v1.7.0
   hooks:
   - id: blacken-docs
-    args: ['--skip-errors']
+    args: [--skip-errors]
     files: ^docs/.*\.rst
     additional_dependencies: [black==20.8b1]
 
@@ -53,7 +53,7 @@ repos:
   hooks:
   - id: populate-pylint-requirements
     files: ^(dev-)?requirements\.txt$
-    args: ['requirements.txt', 'dev-requirements.txt']
+    args: [requirements.txt, dev-requirements.txt]
 
 - repo: https://github.com/pre-commit/mirrors-pylint
   rev: v2.4.4
@@ -73,3 +73,4 @@ repos:
     - python-socketio[client]==5.0.4
     - schedule==1.0.0
     - sqlalchemy==1.3.23
+    - twisted==21.2.0

--- a/.pylintrc
+++ b/.pylintrc
@@ -457,7 +457,7 @@ ignore-on-opaque-inference=yes
 # List of class names for which member attributes should not be checked (useful
 # for classes with dynamically set attributes). This supports the use of
 # qualified names.
-ignored-classes=optparse.Values,thread._local,_thread._local
+ignored-classes=optparse.Values,thread._local,_thread._local,twisted.internet.reactor
 
 # List of module names for which member attributes should not be checked
 # (useful for modules/projects where namespaces are manipulated during runtime

--- a/binance_trade_bot/crypto_trading.py
+++ b/binance_trade_bot/crypto_trading.py
@@ -16,7 +16,6 @@ def main():
     config = Config()
     db = Database(logger, config)
     manager = BinanceAPIManager(config, db, logger)
-
     trader = AutoTrader(manager, db, logger, config)
 
     logger.info("Creating database schema if it doesn't already exist")

--- a/binance_trade_bot/crypto_trading.py
+++ b/binance_trade_bot/crypto_trading.py
@@ -17,10 +17,6 @@ def main():
     db = Database(logger, config)
     manager = BinanceAPIManager(config, db, logger)
 
-    while len(manager.cache) == 0:
-        logger.info("Waiting for ticker prices to update in memory, sleeping for 2 seconds")
-        time.sleep(2)
-
     trader = AutoTrader(manager, db, logger, config)
 
     logger.info("Creating database schema if it doesn't already exist")

--- a/binance_trade_bot/crypto_trading.py
+++ b/binance_trade_bot/crypto_trading.py
@@ -16,6 +16,11 @@ def main():
     config = Config()
     db = Database(logger, config)
     manager = BinanceAPIManager(config, db, logger)
+
+    while len(manager.cache) == 0:
+        logger.info("Waiting for ticker prices to update in memory, sleeping for 2 seconds")
+        time.sleep(2)
+
     trader = AutoTrader(manager, db, logger, config)
 
     logger.info("Creating database schema if it doesn't already exist")

--- a/binance_trade_bot/crypto_trading.py
+++ b/binance_trade_bot/crypto_trading.py
@@ -1,6 +1,8 @@
 #!python3
 import time
 
+from twisted.internet import reactor
+
 from .auto_trader import AutoTrader
 from .binance_api_manager import BinanceAPIManager
 from .config import Config
@@ -32,7 +34,10 @@ def main():
     schedule.every(1).minutes.do(trader.update_values).tag("updating value history")
     schedule.every(1).minutes.do(db.prune_scout_history).tag("pruning scout history")
     schedule.every(1).hours.do(db.prune_value_history).tag("pruning value history")
-
-    while True:
-        schedule.run_pending()
-        time.sleep(1)
+    try:
+        while True:
+            schedule.run_pending()
+            time.sleep(1)
+    finally:
+        manager.bm.close()
+        reactor.stop()

--- a/binance_trade_bot/database.py
+++ b/binance_trade_bot/database.py
@@ -19,7 +19,7 @@ class Database:
     def __init__(self, logger: Logger, config: Config, uri="sqlite:///data/crypto_trading.db"):
         self.logger = logger
         self.config = config
-        self.engine = create_engine(uri + "?check_same_thread=False")
+        self.engine = create_engine(uri, connect_args={"check_same_thread": False})
         self.SessionMaker = sessionmaker(bind=self.engine)
         self.socketio_client = Client()
 

--- a/binance_trade_bot/database.py
+++ b/binance_trade_bot/database.py
@@ -19,7 +19,7 @@ class Database:
     def __init__(self, logger: Logger, config: Config, uri="sqlite:///data/crypto_trading.db"):
         self.logger = logger
         self.config = config
-        self.engine = create_engine(uri)
+        self.engine = create_engine(uri + "?check_same_thread=False")
         self.SessionMaker = sessionmaker(bind=self.engine)
         self.socketio_client = Client()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ flask-cors==3.0.10
 flask-socketio==5.0.1
 eventlet==0.30.2
 python-socketio[client]==5.0.4
+twisted==21.2.0


### PR DESCRIPTION
This change implements the Binance WebSocket client as a quick patch for `get_all_market_tickers` to help with API rate limits since it appears this API is called the most frequently.

I probably won't have time to do any more work on this until next weekend, so if anyone wants to pick it up, I have a list of items I was planning but didn't have time to do.

- [x] Add initial implementation for getting all market tickers via WebSockets
- [ ] Implement error handling on message processing callback
- [ ] Implement re-connection logic for when WebSockets disconnect
- [ ] Look into creating a new class for handling WebSocket connections


Fixes #118