### PR TITLE
Add tags to pushed docker images

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -11,40 +11,51 @@ jobs:
   Lint:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.7
-    - id: changed-files
-      name: Get Changed Files
-      uses: dorny/paths-filter@v2
-      with:
-        token: ${{ github.token }}
-        list-files: shell
-        filters: |
-          repo:
-            - added|modified:
-              - '**'
-    - name: Set Cache Key
-      run: echo "PY=$(python --version --version | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-    - uses: actions/cache@v2
-      with:
-        path: ~/.cache/pre-commit
-        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-    - name: Check ALL Files On Branch
-      uses: pre-commit/action@v2.0.0
-      if: github.event_name != 'pull_request'
-    - name: Check Changed Files On PR
-      uses: pre-commit/action@v2.0.0
-      if: github.event_name == 'pull_request'
-      with:
-        extra_args: --files ${{ steps.changed-files.outputs.repo_files }}
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - id: changed-files
+        name: Get Changed Files
+        uses: dorny/paths-filter@v2
+        with:
+          token: ${{ github.token }}
+          list-files: shell
+          filters: |
+            repo:
+              - added|modified:
+                - '**'
+      - name: Set Cache Key
+        run: echo "PY=$(python --version --version | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Check ALL Files On Branch
+        uses: pre-commit/action@v2.0.0
+        if: github.event_name != 'pull_request'
+      - name: Check Changed Files On PR
+        uses: pre-commit/action@v2.0.0
+        if: github.event_name == 'pull_request'
+        with:
+          extra_args: --files ${{ steps.changed-files.outputs.repo_files }}
 
   Docker:
     runs-on: ubuntu-latest
     needs: Lint
     steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v0.9.9
+        with:
+          versionSpec: "5.5.x"
+      - name: Version with GitVersion # https://github.com/marketplace/actions/use-actions
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v0.9.9
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -57,10 +68,13 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v2 # https://github.com/marketplace/actions/build-and-push-docker-images
         with:
           platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
           push: ${{ github.event_name == 'push' }}
-          tags: ${{ github.repository }}:latest
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+          tags: |
+            ${{ github.repository }}:latest
+            ${{ github.repository }}:${{ steps.gitversion.outputs.shortsha }}
+            ${{ github.repository }}:${{ steps.gitversion.outputs.major }}
+            ${{ github.repository }}:${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }}
+            ${{ github.repository }}:${{ steps.gitversion.outputs.semVer }}

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,14 @@
+assembly-versioning-scheme: MajorMinorPatch
+mode: Mainline
+branches:
+  master:
+    regex: ^master|^main
+    increment: Minor
+increment: Minor
+ignore:
+  sha: []
+merge-message-formats: {}
+major-version-bump-message: (BREAKING CHANGES?|major)(\(.*?\))?:\s?
+minor-version-bump-message: (feature|minor|feat)(\(.*?\))?:\s?
+patch-version-bump-message: (fix|patch|hotfix)(\(.*?\))?:\s?
+no-bump-message: (build|chore|ci|doc|docs|none|perf|refactor|skip|test)(\(.*?\))?:\s?


### PR DESCRIPTION
As a bot user, 
I want version tags on the pushed docker images, 
so I am able to control which version of the docker image I am running, allowing me to roll back to past images easily.

I have removed the final step which echoed the digest, as this did not seem to be working as expected for the multiple platforms.

Using GitVersion to automatically generate SemVer version numbers, we are able to control the versioning by commit messages if desired, or we could use tags and the docker-meta action if we do not want the versions automatically generated. Let me know if we should explore this further.

The current PR will generate tags as follows for an example build on commit ffac537 that has a version of 1.2.3:
- edeng23/binance-trade-bot:latest
- edeng23/binance-trade-bot:1
- edeng23/binance-trade-bot:1.2
- edeng23/binance-trade-bot:1.2.3
- edeng23/binance-trade-bot:ffac537