### PR TITLE
Add logger.info about chosen strategy on bot start

### DIFF
--- a/binance_trade_bot/crypto_trading.py
+++ b/binance_trade_bot/crypto_trading.py
@@ -21,6 +21,7 @@ def main():
         logger.error("Invalid strategy name")
         return
     trader = strategy(manager, db, logger, config)
+    logger.info(f"Chosen strategy: {config.STRATEGY}")
 
     logger.info("Creating database schema if it doesn't already exist")
     db.create_database()


### PR DESCRIPTION
I think it will be convenient for the bot user to see at the start what strategy is currently running.