### PR TITLE
Fix bridge_scout in default strategy

### DIFF
--- a/binance_trade_bot/auto_trader.py
+++ b/binance_trade_bot/auto_trader.py
@@ -156,7 +156,8 @@ class AutoTrader:
                 if bridge_balance > self.manager.get_min_notional(coin.symbol, self.config.BRIDGE.symbol):
                     self.logger.info(f"Will be purchasing {coin} using bridge coin")
                     self.manager.buy_alt(coin, self.config.BRIDGE, all_tickers)
-                return
+                    return coin
+        return None
 
     def update_values(self):
         """

--- a/binance_trade_bot/strategies/default_strategy.py
+++ b/binance_trade_bot/strategies/default_strategy.py
@@ -41,6 +41,17 @@ class Strategy(AutoTrader):
         self._jump_to_best_coin(current_coin, current_coin_price, all_tickers)
         self.bridge_scout()
 
+    def bridge_scout(self):
+        current_coin = self.db.get_current_coin()
+        if self.manager.get_currency_balance(current_coin.symbol) > self.manager.get_min_notional(
+            current_coin.symbol, self.config.BRIDGE.symbol
+        ):
+            # Only scout if we don't have enough of the current coin
+            return
+        new_coin = super().bridge_scout()
+        if new_coin is not None:
+            self.db.set_current_coin(new_coin)
+
     def initialize_current_coin(self):
         """
         Decide what is the current coin, and set it up in the DB.


### PR DESCRIPTION
Set current coin after jumping from bridge coin

My bad, I forgot to extend the `bridge_scout` method in the default strategy to update the current coin

Also, with the `get_fee` method, `bridge_scout` is really really slow. I think #211 or #208 should be a priority