### PR TITLE
fix retrieval of BNB fees switch on Binance API

### DIFF
--- a/binance_trade_bot/binance_api_manager.py
+++ b/binance_trade_bot/binance_api_manager.py
@@ -29,7 +29,7 @@ class BinanceAPIManager:
 
     @cached(cache=TTLCache(maxsize=1, ttl=60))
     def get_using_bnb_for_fees(self):
-        return self.binance_client.get_bnb_burn_spot_margin()['spotBNBBurn']
+        return self.binance_client.get_bnb_burn_spot_margin()["spotBNBBurn"]
 
     def get_fee(self, origin_coin: Coin, target_coin: Coin, selling: bool):
         base_fee = self.get_trade_fees()[origin_coin + target_coin]

--- a/binance_trade_bot/binance_api_manager.py
+++ b/binance_trade_bot/binance_api_manager.py
@@ -29,7 +29,7 @@ class BinanceAPIManager:
 
     @cached(cache=TTLCache(maxsize=1, ttl=60))
     def get_using_bnb_for_fees(self):
-        return self.binance_client.get_bnb_burn_spot_margin()
+        return self.binance_client.get_bnb_burn_spot_margin()['spotBNBBurn']
 
     def get_fee(self, origin_coin: Coin, target_coin: Coin, selling: bool):
         base_fee = self.get_trade_fees()[origin_coin + target_coin]


### PR DESCRIPTION
The `get_using_bnb_for_fees` function will return an object containing e.g. :

```
{
   "spotBNBBurn":true,
   "interestBNBBurn": false
}
```

Used at is, it will evaluate to true each time. Fix get the `spotBNBBurn` property instead.