### PR TITLE
db: control logging of scout history using a parameter.

### DIFF
--- a/.user.cfg.example
+++ b/.user.cfg.example
@@ -8,3 +8,4 @@ hourToKeepScoutHistory=1
 scout_multiplier=5
 scout_sleep_time=5
 strategy=default
+verbose_scout_logging=False

--- a/binance_trade_bot/config.py
+++ b/binance_trade_bot/config.py
@@ -19,6 +19,7 @@ class Config:  # pylint: disable=too-few-public-methods
             "hourToKeepScoutHistory": "1",
             "tld": "com",
             "strategy": "default",
+            "verbose_scout_logging": False,
         }
 
         if not os.path.exists(CFG_FL_NAME):
@@ -65,3 +66,7 @@ class Config:  # pylint: disable=too-few-public-methods
         self.CURRENT_COIN_SYMBOL = os.environ.get("CURRENT_COIN_SYMBOL") or config.get(USER_CFG_SECTION, "current_coin")
 
         self.STRATEGY = os.environ.get("STRATEGY") or config.get(USER_CFG_SECTION, "strategy")
+
+        self.VERBOSE_SCOUT_LOGGING = os.environ.get("VERBOSE_SCOUT_LOGGING") or config.get(
+            USER_CFG_SECTION, "verbose_scout_logging"
+        )


### PR DESCRIPTION
A lot of people seem to be having issues with the `self.db.log_scout` write overhead.

This PR adds a config using which users can disable it without making code changes. In order to ensure backwards compatibility, the update will also inform users that there's a new param and it needs to be set :)