### PR TITLE
Fix fees for US tld

### DIFF
--- a/binance_trade_bot/binance_api_manager.py
+++ b/binance_trade_bot/binance_api_manager.py
@@ -44,8 +44,7 @@ class BinanceAPIManager:
         fees = self.get_trade_fees()
         if not fees:
             return 0.001
-        else:
-            base_fee = fees[origin_coin + target_coin]
+        base_fee = fees[origin_coin + target_coin]
         if not self.get_using_bnb_for_fees():
             return base_fee
         # The discount is only applied if we have enough BNB to cover the fee

--- a/binance_trade_bot/binance_api_manager.py
+++ b/binance_trade_bot/binance_api_manager.py
@@ -42,13 +42,10 @@ class BinanceAPIManager:
 
     def get_fee(self, origin_coin: Coin, target_coin: Coin, selling: bool):
         fees = self.get_trade_fees()
-
-        # US api returns an empty list for fees currently. No ETA for fix from Binance, so we're defaulting to 0.001 for base_fee.
         if not fees:
             base_fee = 0.001
         else:
             base_fee = fees[origin_coin + target_coin]
-        
         if not self.get_using_bnb_for_fees():
             return base_fee
         # The discount is only applied if we have enough BNB to cover the fee

--- a/binance_trade_bot/binance_api_manager.py
+++ b/binance_trade_bot/binance_api_manager.py
@@ -41,7 +41,14 @@ class BinanceAPIManager:
         return self.binance_client.get_bnb_burn_spot_margin()["spotBNBBurn"]
 
     def get_fee(self, origin_coin: Coin, target_coin: Coin, selling: bool):
-        base_fee = self.get_trade_fees()[origin_coin + target_coin]
+        fees = self.get_trade_fees()
+
+        # US api returns an empty list for fees currently. No ETA for fix from Binance, so we're defaulting to 0.001 for base_fee.
+        if not fees:
+            base_fee = 0.001
+        else:
+            base_fee = fees[origin_coin + target_coin]
+        
         if not self.get_using_bnb_for_fees():
             return base_fee
         # The discount is only applied if we have enough BNB to cover the fee

--- a/binance_trade_bot/binance_api_manager.py
+++ b/binance_trade_bot/binance_api_manager.py
@@ -43,7 +43,7 @@ class BinanceAPIManager:
     def get_fee(self, origin_coin: Coin, target_coin: Coin, selling: bool):
         fees = self.get_trade_fees()
         if not fees:
-            base_fee = 0.001
+            return 0.001
         else:
             base_fee = fees[origin_coin + target_coin]
         if not self.get_using_bnb_for_fees():


### PR DESCRIPTION
The API on Binance.us is buggy and return an empty list. They say that "not everyone can access this api" but they have no details, nor any ETA in resolving the issue. Let's default to 0.001 in that case.