### PR TITLE
bridge_scout not taking into considering market ticker price

### DIFF
--- a/binance_trade_bot/strategies/default_strategy.py
+++ b/binance_trade_bot/strategies/default_strategy.py
@@ -35,9 +35,10 @@ class Strategy(AutoTrader):
 
     def bridge_scout(self):
         current_coin = self.db.get_current_coin()
-        if self.manager.get_currency_balance(current_coin.symbol) * self.manager.get_market_ticker_price(current_coin + self.config.BRIDGE) > self.manager.get_min_notional(
-            current_coin.symbol, self.config.BRIDGE.symbol
-        ):
+        if self.manager.get_currency_balance(current_coin.symbol) * self.manager.get_market_ticker_price(
+            current_coin + self.config.BRIDGE
+        ) > self.manager.get_min_notional(
+            current_coin.symbol, self.config.BRIDGE.symbol):
             # Only scout if we don't have enough of the current coin
             return
         new_coin = super().bridge_scout()

--- a/binance_trade_bot/strategies/default_strategy.py
+++ b/binance_trade_bot/strategies/default_strategy.py
@@ -35,7 +35,7 @@ class Strategy(AutoTrader):
 
     def bridge_scout(self):
         current_coin = self.db.get_current_coin()
-        if self.manager.get_currency_balance(current_coin.symbol) > self.manager.get_min_notional(
+        if self.manager.get_currency_balance(current_coin.symbol) * self.manager.get_market_ticker_price(current_coin + self.config.BRIDGE) > self.manager.get_min_notional(
             current_coin.symbol, self.config.BRIDGE.symbol
         ):
             # Only scout if we don't have enough of the current coin

--- a/binance_trade_bot/strategies/default_strategy.py
+++ b/binance_trade_bot/strategies/default_strategy.py
@@ -37,8 +37,7 @@ class Strategy(AutoTrader):
         current_coin = self.db.get_current_coin()
         if self.manager.get_currency_balance(current_coin.symbol) * self.manager.get_market_ticker_price(
             current_coin + self.config.BRIDGE
-        ) > self.manager.get_min_notional(
-            current_coin.symbol, self.config.BRIDGE.symbol):
+        ) > self.manager.get_min_notional(current_coin.symbol, self.config.BRIDGE.symbol):
             # Only scout if we don't have enough of the current coin
             return
         new_coin = super().bridge_scout()


### PR DESCRIPTION
bridge_scout would perform a comparison against the current coins balance vs the minimal required.
However, it should have been current balance multiplied by the ticker price.

Without this, the bridge_scout would fail the conditional check and perform a full scout of every coin combination causing significant delays in scouting.
