### PR TITLE
Revert changes on strategies

### DIFF
--- a/binance_trade_bot/strategies/default_strategy.py
+++ b/binance_trade_bot/strategies/default_strategy.py
@@ -3,12 +3,18 @@ import sys
 from datetime import datetime
 
 from binance_trade_bot.auto_trader import AutoTrader
+from binance_trade_bot.models import Pair
 
 
 class Strategy(AutoTrader):
     def initialize(self):
         super().initialize()
         self.initialize_current_coin()
+
+    def transaction_through_bridge(self, pair: Pair, all_tickers):
+        super().transaction_through_bridge(pair, all_tickers)
+
+        self.db.set_current_coin(pair.to_coin)
 
     def scout(self):
         """
@@ -32,6 +38,7 @@ class Strategy(AutoTrader):
             return
 
         self._jump_to_best_coin(current_coin, current_coin_price, all_tickers)
+        self.bridge_scout()
 
     def bridge_scout(self):
         current_coin = self.db.get_current_coin()

--- a/binance_trade_bot/strategies/multiple_coins_strategy.py
+++ b/binance_trade_bot/strategies/multiple_coins_strategy.py
@@ -7,14 +7,6 @@ class Strategy(AutoTrader):
         Scout for potential jumps from the current coin to another coin
         """
         all_tickers = self.manager.get_all_market_tickers()
-        have_coin = False
-
-        # last coin bought
-        current_coin = self.db.get_current_coin()
-        current_coin_symbol = ""
-
-        if current_coin is not None:
-            current_coin_symbol = current_coin.symbol
 
         for coin in self.db.get_coins():
             current_coin_balance = self.manager.get_currency_balance(coin.symbol)
@@ -24,12 +16,10 @@ class Strategy(AutoTrader):
                 self.logger.info("Skipping scouting... current coin {} not found".format(coin + self.config.BRIDGE))
                 continue
 
-            min_notional = self.manager.get_min_notional(coin.symbol, self.config.BRIDGE.symbol)
-
-            if coin.symbol != current_coin_symbol and coin_price * current_coin_balance < min_notional:
+            if coin_price * current_coin_balance < self.manager.get_min_notional(
+                coin.symbol, self.config.BRIDGE.symbol
+            ):
                 continue
-
-            have_coin = True
 
             # Display on the console, the current coin+Bridge, so users can see *some* activity and not think the bot
             # has stopped. Not logging though to reduce log size.
@@ -37,5 +27,4 @@ class Strategy(AutoTrader):
 
             self._jump_to_best_coin(coin, coin_price, all_tickers)
 
-        if not have_coin:
-            self.bridge_scout()
+        self.bridge_scout()


### PR DESCRIPTION
I don't think the current version is correct : 

- The multiple coin strategy should never take care of the current_coin value - it should scout for each assets we own, which is not the case anymore I think?
- Both strategies should still scout with the bridge if ever we have no coins, allow to recover from manual failure (cancelling a trade manually, cutting the bot in the middle of a trade, etc).