### PR TITLE
Check order_quantity before creating buy order

### DIFF
--- a/binance_trade_bot/binance_api_manager.py
+++ b/binance_trade_bot/binance_api_manager.py
@@ -304,6 +304,7 @@ class BinanceAPIManager:
             new_balance = self.get_currency_balance(origin_symbol)
 
         self.logger.info(f"Sold {origin_symbol}")
+        self.db.set_current_coin(origin_coin)
 
         trade_log.set_complete(stat["cummulativeQuoteQty"])
 

--- a/binance_trade_bot/binance_api_manager.py
+++ b/binance_trade_bot/binance_api_manager.py
@@ -220,6 +220,10 @@ class BinanceAPIManager:
         from_coin_price = all_tickers.get_price(origin_symbol + target_symbol)
 
         order_quantity = self._buy_quantity(origin_symbol, target_symbol, target_balance, from_coin_price)
+
+        if order_quantity * from_coin_price < self.get_min_notional(origin_symbol, target_symbol):
+            return None
+
         self.logger.info(f"BUY QTY {order_quantity}")
 
         # Try to buy until successful


### PR DESCRIPTION
This PR to resolve 2 issues when recovering the scout in the multiple coin strategy:
- If sold coin and timeout in a buy order, the bot does not update the current coin to calculate the rate base on the sold coin when recovering 
- If the user stops the bot, manual cancel the buy order then start the bot, the bot will keep buying the other coin with quality is zero when reaching the rate.