### PR TITLE
Websocket Support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,3 +75,4 @@ repos:
     - schedule==1.0.0
     - sqlalchemy==1.3.23
     - sqlitedict==1.7.0
+    - twisted==21.2.0

--- a/.pylintrc
+++ b/.pylintrc
@@ -457,7 +457,7 @@ ignore-on-opaque-inference=yes
 # List of class names for which member attributes should not be checked (useful
 # for classes with dynamically set attributes). This supports the use of
 # qualified names.
-ignored-classes=optparse.Values,thread._local,_thread._local
+ignored-classes=optparse.Values,thread._local,_thread._local,twisted.internet.reactor
 
 # List of module names for which member attributes should not be checked
 # (useful for modules/projects where namespaces are manipulated during runtime

--- a/binance_trade_bot/auto_trader.py
+++ b/binance_trade_bot/auto_trader.py
@@ -42,7 +42,7 @@ class AutoTrader:
         result = self.manager.buy_alt(pair.to_coin, self.config.BRIDGE)
         if result is not None:
             self.db.set_current_coin(pair.to_coin)
-            self.update_trade_threshold(pair.to_coin, float(result["price"]))
+            self.update_trade_threshold(pair.to_coin, result.price)
             return result
 
         self.logger.info("Couldn't buy, going back to scouting mode...")

--- a/binance_trade_bot/auto_trader.py
+++ b/binance_trade_bot/auto_trader.py
@@ -3,7 +3,7 @@ from typing import Dict, List
 
 from sqlalchemy.orm import Session
 
-from .binance_api_manager import AllTickers, BinanceAPIManager
+from .binance_api_manager import BinanceAPIManager
 from .config import Config
 from .database import Database
 from .logger import Logger
@@ -20,34 +20,35 @@ class AutoTrader:
     def initialize(self):
         self.initialize_trade_thresholds()
 
-    def transaction_through_bridge(self, pair: Pair, all_tickers: AllTickers):
+    def transaction_through_bridge(self, pair: Pair):
         """
         Jump from the source coin to the destination coin through bridge coin
         """
         can_sell = False
         balance = self.manager.get_currency_balance(pair.from_coin.symbol)
-        from_coin_price = all_tickers.get_price(pair.from_coin + self.config.BRIDGE)
+        from_coin_price = self.manager.get_ticker_price(pair.from_coin + self.config.BRIDGE)
 
-        if balance and balance * from_coin_price > self.manager.get_min_notional(pair.from_coin, self.config.BRIDGE):
+        if balance and balance * from_coin_price > self.manager.get_min_notional(
+            pair.from_coin.symbol, self.config.BRIDGE.symbol
+        ):
             can_sell = True
         else:
             self.logger.info("Skipping sell")
 
-        if can_sell and self.manager.sell_alt(pair.from_coin, self.config.BRIDGE, all_tickers) is None:
+        if can_sell and self.manager.sell_alt(pair.from_coin, self.config.BRIDGE) is None:
             self.logger.info("Couldn't sell, going back to scouting mode...")
             return None
 
-        result = self.manager.buy_alt(pair.to_coin, self.config.BRIDGE, all_tickers)
-
+        result = self.manager.buy_alt(pair.to_coin, self.config.BRIDGE)
         if result is not None:
             self.db.set_current_coin(pair.to_coin)
-            self.update_trade_threshold(pair.to_coin, float(result["price"]), all_tickers)
+            self.update_trade_threshold(pair.to_coin, float(result["price"]))
             return result
 
         self.logger.info("Couldn't buy, going back to scouting mode...")
         return None
 
-    def update_trade_threshold(self, coin: Coin, coin_price: float, all_tickers: AllTickers):
+    def update_trade_threshold(self, coin: Coin, coin_price: float):
         """
         Update all the coins with the threshold of buying the current held coin
         """
@@ -59,7 +60,7 @@ class AutoTrader:
         session: Session
         with self.db.db_session() as session:
             for pair in session.query(Pair).filter(Pair.to_coin == coin):
-                from_coin_price = all_tickers.get_price(pair.from_coin + self.config.BRIDGE)
+                from_coin_price = self.manager.get_ticker_price(pair.from_coin + self.config.BRIDGE)
 
                 if from_coin_price is None:
                     self.logger.info(
@@ -73,8 +74,6 @@ class AutoTrader:
         """
         Initialize the buying threshold of all the coins for trading between them
         """
-        all_tickers = self.manager.get_all_market_tickers()
-
         session: Session
         with self.db.db_session() as session:
             for pair in session.query(Pair).filter(Pair.ratio.is_(None)).all():
@@ -82,14 +81,14 @@ class AutoTrader:
                     continue
                 self.logger.info(f"Initializing {pair.from_coin} vs {pair.to_coin}")
 
-                from_coin_price = all_tickers.get_price(pair.from_coin + self.config.BRIDGE)
+                from_coin_price = self.manager.get_ticker_price(pair.from_coin + self.config.BRIDGE)
                 if from_coin_price is None:
                     self.logger.info(
                         "Skipping initializing {}, symbol not found".format(pair.from_coin + self.config.BRIDGE)
                     )
                     continue
 
-                to_coin_price = all_tickers.get_price(pair.to_coin + self.config.BRIDGE)
+                to_coin_price = self.manager.get_ticker_price(pair.to_coin + self.config.BRIDGE)
                 if to_coin_price is None:
                     self.logger.info(
                         "Skipping initializing {}, symbol not found".format(pair.to_coin + self.config.BRIDGE)
@@ -104,14 +103,14 @@ class AutoTrader:
         """
         raise NotImplementedError()
 
-    def _get_ratios(self, coin: Coin, coin_price: float, all_tickers: AllTickers):
+    def _get_ratios(self, coin: Coin, coin_price):
         """
         Given a coin, get the current price ratio for every other enabled coin
         """
         ratio_dict: Dict[Pair, float] = {}
 
         for pair in self.db.get_pairs_from(coin):
-            optional_coin_price = all_tickers.get_price(pair.to_coin + self.config.BRIDGE)
+            optional_coin_price = self.manager.get_ticker_price(pair.to_coin + self.config.BRIDGE)
 
             if optional_coin_price is None:
                 self.logger.info(
@@ -133,11 +132,11 @@ class AutoTrader:
             ) - pair.ratio
         return ratio_dict
 
-    def _jump_to_best_coin(self, coin: Coin, coin_price: float, all_tickers: AllTickers):
+    def _jump_to_best_coin(self, coin: Coin, coin_price: float):
         """
         Given a coin, search for a coin to jump to
         """
-        ratio_dict = self._get_ratios(coin, coin_price, all_tickers)
+        ratio_dict = self._get_ratios(coin, coin_price)
 
         # keep only ratios bigger than zero
         ratio_dict = {k: v for k, v in ratio_dict.items() if v > 0}
@@ -146,27 +145,26 @@ class AutoTrader:
         if ratio_dict:
             best_pair = max(ratio_dict, key=ratio_dict.get)
             self.logger.info(f"Will be jumping from {coin} to {best_pair.to_coin_id}")
-            self.transaction_through_bridge(best_pair, all_tickers)
+            self.transaction_through_bridge(best_pair)
 
     def bridge_scout(self):
         """
         If we have any bridge coin leftover, buy a coin with it that we won't immediately trade out of
         """
         bridge_balance = self.manager.get_currency_balance(self.config.BRIDGE.symbol)
-        all_tickers = self.manager.get_all_market_tickers()
 
         for coin in self.db.get_coins():
-            current_coin_price = all_tickers.get_price(coin + self.config.BRIDGE)
+            current_coin_price = self.manager.get_ticker_price(coin + self.config.BRIDGE)
 
             if current_coin_price is None:
                 continue
 
-            ratio_dict = self._get_ratios(coin, current_coin_price, all_tickers)
+            ratio_dict = self._get_ratios(coin, current_coin_price)
             if not any(v > 0 for v in ratio_dict.values()):
                 # There will only be one coin where all the ratios are negative. When we find it, buy it if we can
                 if bridge_balance > self.manager.get_min_notional(coin.symbol, self.config.BRIDGE.symbol):
                     self.logger.info(f"Will be purchasing {coin} using bridge coin")
-                    self.manager.buy_alt(coin, self.config.BRIDGE, all_tickers)
+                    self.manager.buy_alt(coin, self.config.BRIDGE)
                     return coin
         return None
 
@@ -174,8 +172,6 @@ class AutoTrader:
         """
         Log current value state of all altcoin balances against BTC and USDT in DB.
         """
-        all_ticker_values = self.manager.get_all_market_tickers()
-
         now = datetime.now()
 
         session: Session
@@ -185,8 +181,8 @@ class AutoTrader:
                 balance = self.manager.get_currency_balance(coin.symbol)
                 if balance == 0:
                     continue
-                usd_value = all_ticker_values.get_price(coin + "USDT")
-                btc_value = all_ticker_values.get_price(coin + "BTC")
+                usd_value = self.manager.get_ticker_price(coin + "USDT")
+                btc_value = self.manager.get_ticker_price(coin + "BTC")
                 cv = CoinValue(coin, balance, usd_value, btc_value, datetime=now)
                 session.add(cv)
                 self.db.send_update(cv)

--- a/binance_trade_bot/backtest.py
+++ b/binance_trade_bot/backtest.py
@@ -5,6 +5,7 @@ from typing import Dict
 from sqlitedict import SqliteDict
 
 from .binance_api_manager import BinanceAPIManager
+from .binance_stream_manager import BinanceOrder
 from .config import Config
 from .database import Database
 from .logger import Logger
@@ -80,7 +81,10 @@ class MockBinanceManager(BinanceAPIManager):
             f"Bought {origin_symbol}, balance now: {self.balances[origin_symbol]} - bridge: "
             f"{self.balances[target_symbol]}"
         )
-        return {"price": from_coin_price}
+
+        event = {"s": None, "S": None, "o": None, "i": None, "Z": 0, "X": None, "p": from_coin_price, "T": None}
+
+        return BinanceOrder(event)
 
     def sell_alt(self, origin_coin: Coin, target_coin: Coin):
         origin_symbol = origin_coin.symbol

--- a/binance_trade_bot/backtest.py
+++ b/binance_trade_bot/backtest.py
@@ -57,7 +57,7 @@ class MockBinanceManager(BinanceAPIManager):
             val = cache.get(key, None)
         return val
 
-    def get_currency_balance(self, currency_symbol: str):
+    def get_currency_balance(self, currency_symbol: str, force=False):
         """
         Get balance of a specific coin
         """

--- a/binance_trade_bot/backtest.py
+++ b/binance_trade_bot/backtest.py
@@ -4,7 +4,7 @@ from typing import Dict
 
 from sqlitedict import SqliteDict
 
-from .binance_api_manager import AllTickers, BinanceAPIManager
+from .binance_api_manager import BinanceAPIManager
 from .config import Config
 from .database import Database
 from .logger import Logger
@@ -12,14 +12,6 @@ from .models import Coin, Pair
 from .strategies import get_strategy
 
 cache = SqliteDict("data/backtest_cache.db")
-
-
-class FakeAllTickers(AllTickers):  # pylint: disable=too-few-public-methods
-    def __init__(self, manager: "MockBinanceManager"):  # pylint: disable=super-init-not-called
-        self.manager = manager
-
-    def get_price(self, ticker_symbol):
-        return self.manager.get_market_ticker_price(ticker_symbol)
 
 
 class MockBinanceManager(BinanceAPIManager):
@@ -39,16 +31,10 @@ class MockBinanceManager(BinanceAPIManager):
     def increment(self, interval=1):
         self.datetime += timedelta(minutes=interval)
 
-    def get_all_market_tickers(self):
-        """
-        Get ticker price of all coins
-        """
-        return FakeAllTickers(self)
-
     def get_fee(self, origin_coin: Coin, target_coin: Coin, selling: bool):
         return 0.0075
 
-    def get_market_ticker_price(self, ticker_symbol: str):
+    def get_ticker_price(self, ticker_symbol: str):
         """
         Get ticker price of a specific coin
         """
@@ -77,12 +63,12 @@ class MockBinanceManager(BinanceAPIManager):
         """
         return self.balances.get(currency_symbol, 0)
 
-    def buy_alt(self, origin_coin: Coin, target_coin: Coin, all_tickers: AllTickers):
+    def buy_alt(self, origin_coin: Coin, target_coin: Coin):
         origin_symbol = origin_coin.symbol
         target_symbol = target_coin.symbol
 
         target_balance = self.get_currency_balance(target_symbol)
-        from_coin_price = all_tickers.get_price(origin_symbol + target_symbol)
+        from_coin_price = self.get_ticker_price(origin_symbol + target_symbol)
 
         order_quantity = self._buy_quantity(origin_symbol, target_symbol, target_balance, from_coin_price)
         target_quantity = order_quantity * from_coin_price
@@ -96,12 +82,12 @@ class MockBinanceManager(BinanceAPIManager):
         )
         return {"price": from_coin_price}
 
-    def sell_alt(self, origin_coin: Coin, target_coin: Coin, all_tickers: AllTickers):
+    def sell_alt(self, origin_coin: Coin, target_coin: Coin):
         origin_symbol = origin_coin.symbol
         target_symbol = target_coin.symbol
 
         origin_balance = self.get_currency_balance(origin_symbol)
-        from_coin_price = all_tickers.get_price(origin_symbol + target_symbol)
+        from_coin_price = self.get_ticker_price(origin_symbol + target_symbol)
 
         order_quantity = self._sell_quantity(origin_symbol, target_symbol, origin_balance)
         target_quantity = order_quantity * from_coin_price
@@ -122,12 +108,12 @@ class MockBinanceManager(BinanceAPIManager):
                 if coin == target_symbol:
                     total += balance
                 else:
-                    price = self.get_market_ticker_price(target_symbol + coin)
+                    price = self.get_ticker_price(target_symbol + coin)
                     if price is None:
                         continue
                     total += balance / price
             else:
-                price = self.get_market_ticker_price(coin + target_symbol)
+                price = self.get_ticker_price(coin + target_symbol)
                 if price is None:
                     continue
                 total += price * balance
@@ -175,7 +161,7 @@ def backtest(
 
     starting_coin = db.get_coin(starting_coin or config.SUPPORTED_COIN_LIST[0])
     if manager.get_currency_balance(starting_coin.symbol) == 0:
-        manager.buy_alt(starting_coin, config.BRIDGE, manager.get_all_market_tickers())
+        manager.buy_alt(starting_coin, config.BRIDGE)
     db.set_current_coin(starting_coin)
 
     strategy = get_strategy(config.STRATEGY)

--- a/binance_trade_bot/binance_api_manager.py
+++ b/binance_trade_bot/binance_api_manager.py
@@ -39,6 +39,7 @@ class BinanceAPIManager:
         base_fee = self.get_trade_fees()[origin_coin + target_coin]
         if not self.get_using_bnb_for_fees():
             return base_fee
+
         # The discount is only applied if we have enough BNB to cover the fee
         amount_trading = (
             self._sell_quantity(origin_coin.symbol, target_coin.symbol)
@@ -76,7 +77,7 @@ class BinanceAPIManager:
 
         return price
 
-    def get_currency_balance(self, currency_symbol: str):
+    def get_currency_balance(self, currency_symbol: str) -> float:
         """
         Get balance of a specific coin
         """
@@ -86,7 +87,10 @@ class BinanceAPIManager:
                 currency_balance["asset"]: float(currency_balance["free"])
                 for currency_balance in self.binance_client.get_account()["balances"]
             }
-            balance = self.cache.balances.get(currency_symbol, None)
+            if currency_symbol not in self.cache.balances:
+                self.cache.balances[currency_symbol] = 0.0
+                return 0.0
+            return self.cache.balances.get(currency_symbol, 0.0)
 
         return balance
 

--- a/binance_trade_bot/binance_api_manager.py
+++ b/binance_trade_bot/binance_api_manager.py
@@ -1,12 +1,12 @@
 import math
 import time
-from typing import Dict
+from typing import Dict, Optional
 
 from binance.client import Client
 from binance.exceptions import BinanceAPIException
 from cachetools import TTLCache, cached
 
-from .binance_stream_manager import BinanceCache, BinanceStreamManager
+from .binance_stream_manager import BinanceCache, BinanceOrder, BinanceStreamManager
 from .config import Config
 from .database import Database
 from .logger import Logger
@@ -125,23 +125,20 @@ class BinanceAPIManager:
     def get_min_notional(self, origin_symbol: str, target_symbol: str):
         return float(self.get_symbol_filter(origin_symbol, target_symbol, "MIN_NOTIONAL")["minNotional"])
 
-    def wait_for_order(self, origin_symbol, target_symbol, order_id):
+    def wait_for_order(
+        self, order_id, origin_symbol: str, target_symbol: str
+    ) -> Optional[BinanceOrder]:  # pylint: disable=unsubscriptable-object
         while True:
-            try:
-                order_status = self.binance_client.get_order(symbol=origin_symbol + target_symbol, orderId=order_id)
+            order_status: BinanceOrder = self.cache.orders.get(order_id, None)
+            if order_status is not None:
                 break
-            except BinanceAPIException as e:
-                self.logger.info(e)
-                time.sleep(1)
-            except Exception as e:  # pylint: disable=broad-except
-                self.logger.info(f"Unexpected Error: {e}")
-                time.sleep(1)
+            time.sleep(1)
 
         self.logger.info(order_status)
 
-        while order_status["status"] != "FILLED":
+        while order_status.status != "FILLED":
             try:
-                order_status = self.binance_client.get_order(symbol=origin_symbol + target_symbol, orderId=order_id)
+                order_status = self.cache.orders.get(order_id, None)
 
                 if self._should_cancel_order(order_status):
                     cancel_order = None
@@ -152,7 +149,7 @@ class BinanceAPIManager:
                     self.logger.info("Order timeout, canceled...")
 
                     # sell partially
-                    if order_status["status"] == "PARTIALLY_FILLED" and order_status["side"] == "BUY":
+                    if order_status.status == "PARTIALLY_FILLED" and order_status.side == "BUY":
                         self.logger.info("Sell partially filled amount")
 
                         order_quantity = self._sell_quantity(origin_symbol, target_symbol)
@@ -165,7 +162,7 @@ class BinanceAPIManager:
                     self.logger.info("Going back to scouting mode...")
                     return None
 
-                if order_status["status"] == "CANCELED":
+                if order_status.status == "CANCELED":
                     self.logger.info("Order is canceled, going back to scouting mode...")
                     return None
 
@@ -180,29 +177,29 @@ class BinanceAPIManager:
         return order_status
 
     def _should_cancel_order(self, order_status):
-        minutes = (time.time() - order_status["time"] / 1000) / 60
+        minutes = (time.time() - order_status.time / 1000) / 60
         timeout = 0
 
-        if order_status["side"] == "SELL":
+        if order_status.side == "SELL":
             timeout = float(self.config.SELL_TIMEOUT)
         else:
             timeout = float(self.config.BUY_TIMEOUT)
 
-        if timeout and minutes > timeout and order_status["status"] == "NEW":
+        if timeout and minutes > timeout and order_status.status == "NEW":
             return True
 
-        if timeout and minutes > timeout and order_status["status"] == "PARTIALLY_FILLED":
-            if order_status["side"] == "SELL":
+        if timeout and minutes > timeout and order_status.status == "PARTIALLY_FILLED":
+            if order_status.side == "SELL":
                 return True
 
-            if order_status["side"] == "BUY":
-                current_price = self.get_ticker_price(order_status["symbol"])
-                if float(current_price) * (1 - 0.001) > float(order_status["price"]):
+            if order_status.side == "BUY":
+                current_price = self.get_ticker_price(order_status.symbol)
+                if float(current_price) * (1 - 0.001) > float(order_status.price):
                     return True
 
         return False
 
-    def buy_alt(self, origin_coin: Coin, target_coin: Coin):
+    def buy_alt(self, origin_coin: Coin, target_coin: Coin) -> BinanceOrder:
         return self.retry(self._buy_alt, origin_coin, target_coin)
 
     def _buy_quantity(
@@ -247,17 +244,18 @@ class BinanceAPIManager:
 
         trade_log.set_ordered(origin_balance, target_balance, order_quantity)
 
-        stat = self.wait_for_order(origin_symbol, target_symbol, order["orderId"])
+        order = self.wait_for_order(order["orderId"], origin_symbol, target_symbol)
 
-        if stat is None:
+        if order is None:
             return None
 
         self.logger.info(f"Bought {origin_symbol}")
-        trade_log.set_complete(stat["cummulativeQuoteQty"])
+
+        trade_log.set_complete(order.cumulative_quote_qty)
 
         return order
 
-    def sell_alt(self, origin_coin: Coin, target_coin: Coin):
+    def sell_alt(self, origin_coin: Coin, target_coin: Coin) -> BinanceOrder:
         return self.retry(self._sell_alt, origin_coin, target_coin)
 
     def _sell_quantity(self, origin_symbol: str, target_symbol: str, origin_balance: float = None):
@@ -286,7 +284,7 @@ class BinanceAPIManager:
         while order is None:
             # Should sell at calculated price to avoid lost coin
             order = self.binance_client.order_limit_sell(
-                symbol=origin_symbol + target_symbol, quantity=(order_quantity), price=from_coin_price
+                symbol=origin_symbol + target_symbol, quantity=order_quantity, price=from_coin_price
             )
 
         self.logger.info("order")
@@ -297,9 +295,9 @@ class BinanceAPIManager:
         # Binance server can take some time to save the order
         self.logger.info("Waiting for Binance")
 
-        stat = self.wait_for_order(origin_symbol, target_symbol, order["orderId"])
+        order = self.wait_for_order(order["orderId"], origin_symbol, target_symbol)
 
-        if stat is None:
+        if order is None:
             return None
 
         new_balance = self.get_currency_balance(origin_symbol)
@@ -308,6 +306,6 @@ class BinanceAPIManager:
 
         self.logger.info(f"Sold {origin_symbol}")
 
-        trade_log.set_complete(stat["cummulativeQuoteQty"])
+        trade_log.set_complete(order.cumulative_quote_qty)
 
         return order

--- a/binance_trade_bot/binance_api_manager.py
+++ b/binance_trade_bot/binance_api_manager.py
@@ -66,11 +66,13 @@ class BinanceAPIManager:
         Get ticker price of a specific coin
         """
         price = self.cache.ticker_values.get(ticker_symbol, None)
-        if price is None:
+        if price is None and ticker_symbol not in self.cache.non_existent_tickers:
             self.cache.ticker_values = {
                 ticker["symbol"]: float(ticker["price"]) for ticker in self.binance_client.get_symbol_ticker()
             }
             price = self.cache.ticker_values.get(ticker_symbol, None)
+            if price is None:
+                self.cache.non_existent_tickers.add(ticker_symbol)
 
         return price
 

--- a/binance_trade_bot/binance_api_manager.py
+++ b/binance_trade_bot/binance_api_manager.py
@@ -71,8 +71,10 @@ class BinanceAPIManager:
             self.cache.ticker_values = {
                 ticker["symbol"]: float(ticker["price"]) for ticker in self.binance_client.get_symbol_ticker()
             }
+            self.logger.debug(f"Fetched all ticker prices: {self.cache.ticker_values}")
             price = self.cache.ticker_values.get(ticker_symbol, None)
             if price is None:
+                self.logger.info(f"Ticker does not exist: {ticker_symbol} - will not be fetched from now on")
                 self.cache.non_existent_tickers.add(ticker_symbol)
 
         return price
@@ -87,6 +89,7 @@ class BinanceAPIManager:
                 currency_balance["asset"]: float(currency_balance["free"])
                 for currency_balance in self.binance_client.get_account()["balances"]
             }
+            self.logger.debug(f"Fetched all balances: {self.cache.balances}")
             if currency_symbol not in self.cache.balances:
                 self.cache.balances[currency_symbol] = 0.0
                 return 0.0
@@ -101,9 +104,9 @@ class BinanceAPIManager:
             try:
                 return func(*args, **kwargs)
             except Exception as e:  # pylint: disable=broad-except
-                self.logger.info("Failed to Buy/Sell. Trying Again.")
+                self.logger.warning(f"Failed to Buy/Sell. Trying Again (attempt {attempts}/20)")
                 if attempts == 0:
-                    self.logger.info(e)
+                    self.logger.warning(e)
                 attempts += 1
         return None
 
@@ -132,13 +135,16 @@ class BinanceAPIManager:
             order_status: BinanceOrder = self.cache.orders.get(order_id, None)
             if order_status is not None:
                 break
+            self.logger.debug(f"Waiting for order {order_id} to be created")
             time.sleep(1)
 
-        self.logger.info(order_status)
+        self.logger.debug(f"Order created: {order_status}")
 
         while order_status.status != "FILLED":
             try:
                 order_status = self.cache.orders.get(order_id, None)
+
+                self.logger.debug(f"Waiting for order {order_id} to be filled")
 
                 if self._should_cancel_order(order_status):
                     cancel_order = None
@@ -173,6 +179,8 @@ class BinanceAPIManager:
             except Exception as e:  # pylint: disable=broad-except
                 self.logger.info(f"Unexpected Error: {e}")
                 time.sleep(1)
+
+        self.logger.debug(f"Order filled: {order_status}")
 
         return order_status
 
@@ -241,7 +249,7 @@ class BinanceAPIManager:
                 self.logger.info(e)
                 time.sleep(1)
             except Exception as e:  # pylint: disable=broad-except
-                self.logger.info(f"Unexpected Error: {e}")
+                self.logger.warning(f"Unexpected Error: {e}")
 
         trade_log.set_ordered(origin_balance, target_balance, order_quantity)
 
@@ -293,9 +301,6 @@ class BinanceAPIManager:
         self.logger.info(order)
 
         trade_log.set_ordered(origin_balance, target_balance, order_quantity)
-
-        # Binance server can take some time to save the order
-        self.logger.info("Waiting for Binance")
 
         order = self.wait_for_order(order["orderId"], origin_symbol, target_symbol)
 

--- a/binance_trade_bot/binance_api_manager.py
+++ b/binance_trade_bot/binance_api_manager.py
@@ -77,12 +77,12 @@ class BinanceAPIManager:
 
         return price
 
-    def get_currency_balance(self, currency_symbol: str) -> float:
+    def get_currency_balance(self, currency_symbol: str, force=False) -> float:
         """
         Get balance of a specific coin
         """
         balance = self.cache.balances.get(currency_symbol, None)
-        if balance is None:
+        if force or balance is None:
             self.cache.balances = {
                 currency_balance["asset"]: float(currency_balance["free"])
                 for currency_balance in self.binance_client.get_account()["balances"]
@@ -219,6 +219,7 @@ class BinanceAPIManager:
         origin_symbol = origin_coin.symbol
         target_symbol = target_coin.symbol
 
+        self.cache.balances.clear()
         origin_balance = self.get_currency_balance(origin_symbol)
         target_balance = self.get_currency_balance(target_symbol)
         from_coin_price = self.get_ticker_price(origin_symbol + target_symbol)
@@ -272,6 +273,7 @@ class BinanceAPIManager:
         origin_symbol = origin_coin.symbol
         target_symbol = target_coin.symbol
 
+        self.cache.balances.clear()
         origin_balance = self.get_currency_balance(origin_symbol)
         target_balance = self.get_currency_balance(target_symbol)
         from_coin_price = self.get_ticker_price(origin_symbol + target_symbol)
@@ -302,7 +304,7 @@ class BinanceAPIManager:
 
         new_balance = self.get_currency_balance(origin_symbol)
         while new_balance >= origin_balance:
-            new_balance = self.get_currency_balance(origin_symbol)
+            new_balance = self.get_currency_balance(origin_symbol, True)
 
         self.logger.info(f"Sold {origin_symbol}")
 

--- a/binance_trade_bot/binance_api_manager.py
+++ b/binance_trade_bot/binance_api_manager.py
@@ -1,24 +1,16 @@
 import math
 import time
-from typing import Dict, List
+from typing import Dict
 
 from binance.client import Client
 from binance.exceptions import BinanceAPIException
 from cachetools import TTLCache, cached
 
+from .binance_stream_manager import BinanceCache, BinanceStreamManager
 from .config import Config
 from .database import Database
 from .logger import Logger
 from .models import Coin
-
-
-class AllTickers:  # pylint: disable=too-few-public-methods
-    def __init__(self, all_tickers: List[Dict]):
-        self.all_tickers = all_tickers
-
-    def get_price(self, ticker_symbol):
-        ticker = next((t for t in self.all_tickers if t["symbol"] == ticker_symbol), None)
-        return float(ticker["price"]) if ticker else None
 
 
 class BinanceAPIManager:
@@ -31,6 +23,9 @@ class BinanceAPIManager:
         self.db = db
         self.logger = logger
         self.config = config
+
+        self.cache = BinanceCache()
+        self.stream_manager = BinanceStreamManager(self.cache, self.binance_client, self.logger)
 
     @cached(cache=TTLCache(maxsize=1, ttl=43200))
     def get_trade_fees(self) -> Dict[str, float]:
@@ -50,42 +45,48 @@ class BinanceAPIManager:
             if selling
             else self._buy_quantity(origin_coin.symbol, target_coin.symbol)
         )
+
         fee_amount = amount_trading * base_fee * 0.75
         if origin_coin.symbol == "BNB":
             fee_amount_bnb = fee_amount
         else:
-            origin_price = self.get_market_ticker_price(origin_coin + Coin("BNB"))
+            origin_price = self.get_ticker_price(origin_coin + Coin("BNB"))
             if origin_price is None:
                 return base_fee
             fee_amount_bnb = fee_amount * origin_price
+
         bnb_balance = self.get_currency_balance("BNB")
+
         if bnb_balance >= fee_amount_bnb:
             return base_fee * 0.75
         return base_fee
 
-    def get_all_market_tickers(self) -> AllTickers:
-        """
-        Get ticker price of all coins
-        """
-        return AllTickers(self.binance_client.get_all_tickers())
-
-    def get_market_ticker_price(self, ticker_symbol: str):
+    def get_ticker_price(self, ticker_symbol: str):
         """
         Get ticker price of a specific coin
         """
-        for ticker in self.binance_client.get_symbol_ticker():
-            if ticker["symbol"] == ticker_symbol:
-                return float(ticker["price"])
-        return None
+        price = self.cache.ticker_values.get(ticker_symbol, None)
+        if price is None:
+            self.cache.ticker_values = {
+                ticker["symbol"]: float(ticker["price"]) for ticker in self.binance_client.get_symbol_ticker()
+            }
+            price = self.cache.ticker_values.get(ticker_symbol, None)
+
+        return price
 
     def get_currency_balance(self, currency_symbol: str):
         """
         Get balance of a specific coin
         """
-        for currency_balance in self.binance_client.get_account()["balances"]:
-            if currency_balance["asset"] == currency_symbol:
-                return float(currency_balance["free"])
-        return None
+        balance = self.cache.balances.get(currency_symbol, None)
+        if balance is None:
+            self.cache.balances = {
+                currency_balance["asset"]: float(currency_balance["free"])
+                for currency_balance in self.binance_client.get_account()["balances"]
+            }
+            balance = self.cache.balances.get(currency_symbol, None)
+
+        return balance
 
     def retry(self, func, *args, **kwargs):
         time.sleep(1)
@@ -189,25 +190,25 @@ class BinanceAPIManager:
                 return True
 
             if order_status["side"] == "BUY":
-                current_price = self.get_market_ticker_price(order_status["symbol"])
+                current_price = self.get_ticker_price(order_status["symbol"])
                 if float(current_price) * (1 - 0.001) > float(order_status["price"]):
                     return True
 
         return False
 
-    def buy_alt(self, origin_coin: Coin, target_coin: Coin, all_tickers: AllTickers):
-        return self.retry(self._buy_alt, origin_coin, target_coin, all_tickers)
+    def buy_alt(self, origin_coin: Coin, target_coin: Coin):
+        return self.retry(self._buy_alt, origin_coin, target_coin)
 
     def _buy_quantity(
         self, origin_symbol: str, target_symbol: str, target_balance: float = None, from_coin_price: float = None
     ):
         target_balance = target_balance or self.get_currency_balance(target_symbol)
-        from_coin_price = from_coin_price or self.get_all_market_tickers().get_price(origin_symbol + target_symbol)
+        from_coin_price = from_coin_price or self.get_ticker_price(origin_symbol + target_symbol)
 
         origin_tick = self.get_alt_tick(origin_symbol, target_symbol)
         return math.floor(target_balance * 10 ** origin_tick / from_coin_price) / float(10 ** origin_tick)
 
-    def _buy_alt(self, origin_coin: Coin, target_coin: Coin, all_tickers):
+    def _buy_alt(self, origin_coin: Coin, target_coin: Coin):
         """
         Buy altcoin
         """
@@ -217,7 +218,7 @@ class BinanceAPIManager:
 
         origin_balance = self.get_currency_balance(origin_symbol)
         target_balance = self.get_currency_balance(target_symbol)
-        from_coin_price = all_tickers.get_price(origin_symbol + target_symbol)
+        from_coin_price = self.get_ticker_price(origin_symbol + target_symbol)
 
         order_quantity = self._buy_quantity(origin_symbol, target_symbol, target_balance, from_coin_price)
         self.logger.info(f"BUY QTY {order_quantity}")
@@ -250,8 +251,8 @@ class BinanceAPIManager:
 
         return order
 
-    def sell_alt(self, origin_coin: Coin, target_coin: Coin, all_tickers: AllTickers):
-        return self.retry(self._sell_alt, origin_coin, target_coin, all_tickers)
+    def sell_alt(self, origin_coin: Coin, target_coin: Coin):
+        return self.retry(self._sell_alt, origin_coin, target_coin)
 
     def _sell_quantity(self, origin_symbol: str, target_symbol: str, origin_balance: float = None):
         origin_balance = origin_balance or self.get_currency_balance(origin_symbol)
@@ -259,7 +260,7 @@ class BinanceAPIManager:
         origin_tick = self.get_alt_tick(origin_symbol, target_symbol)
         return math.floor(origin_balance * 10 ** origin_tick) / float(10 ** origin_tick)
 
-    def _sell_alt(self, origin_coin: Coin, target_coin: Coin, all_tickers: AllTickers):
+    def _sell_alt(self, origin_coin: Coin, target_coin: Coin):
         """
         Sell altcoin
         """
@@ -269,7 +270,7 @@ class BinanceAPIManager:
 
         origin_balance = self.get_currency_balance(origin_symbol)
         target_balance = self.get_currency_balance(target_symbol)
-        from_coin_price = all_tickers.get_price(origin_symbol + target_symbol)
+        from_coin_price = self.get_ticker_price(origin_symbol + target_symbol)
 
         order_quantity = self._sell_quantity(origin_symbol, target_symbol, origin_balance)
         self.logger.info(f"Selling {order_quantity} of {origin_symbol}")

--- a/binance_trade_bot/binance_stream_manager.py
+++ b/binance_trade_bot/binance_stream_manager.py
@@ -1,0 +1,98 @@
+import time
+from typing import Dict
+
+from autobahn.twisted.websocket import connectWS
+from binance.client import Client
+from binance.websockets import BinanceClientFactory, BinanceClientProtocol, BinanceSocketManager
+from twisted.internet import reactor, ssl
+
+from .logger import Logger
+
+
+class CustomBinanceSocketManager(BinanceSocketManager):
+    """
+    A custom implementation that fixes disconnection detection
+    """
+
+    def _start_socket(self, path, callback, prefix="ws/"):
+        if path in self._conns:
+            return False
+
+        factory_url = self.STREAM_URL + prefix + path
+        factory = BinanceClientFactory(factory_url)
+        factory.protocol = BinanceClientProtocol
+        factory.callback = callback
+        factory.reconnect = True
+        factory.setProtocolOptions(autoPingInterval=5, autoPingTimeout=5)
+        context_factory = ssl.ClientContextFactory()
+
+        self._conns[path] = connectWS(factory, context_factory)
+        return path
+
+
+class BinanceCache:  # pylint: disable=too-few-public-methods
+    ticker_values: Dict[str, float] = {}
+    balances: Dict[str, float] = {}
+
+
+class BinanceStreamManager:
+    def __init__(self, cache: BinanceCache, client: Client, logger: Logger):
+        self.cache = cache
+        self.logger = logger
+        self.bm = CustomBinanceSocketManager(client)
+
+        self.ticker_price_socket_conn_key = self._start_ticker_values_socket()
+        self.user_socket_conn_key = self._start_user_socket()
+
+        self.bm.start()
+
+    def retry(self, func, *args, **kwargs):
+        attempts = 0
+        time.sleep(1 + attempts * 5)
+        while attempts < 20:
+            try:
+                return func(*args, **kwargs)
+            except Exception as e:  # pylint: disable=broad-except
+                self.logger.info("Failed to connect to websocket. Trying Again.")
+                if attempts == 0:
+                    self.logger.info(e)
+                attempts += 1
+        return None
+
+    def _start_ticker_values_socket(self):
+        conn = self.bm.start_ticker_socket(self._process_ticker_values)
+        if conn:
+            return conn
+        return self.retry(self._start_ticker_values_socket)
+
+    def _start_user_socket(self):
+        conn = self.bm.start_user_socket(self._process_user_socket)
+        if conn:
+            return conn
+        return self.retry(self._start_user_socket)
+
+    def _process_ticker_values(self, msg):
+        if "e" in msg and msg["e"] == "error":
+            self.bm.stop_socket(self.ticker_price_socket_conn_key)
+            self.ticker_price_socket_conn_key = self._start_ticker_values_socket()
+            self.cache.ticker_values.clear()
+            return
+
+        for ticker in msg:
+            self.cache.ticker_values[ticker["s"]] = float(ticker["c"])
+
+    def _process_user_socket(self, msg):
+        if msg["e"] == "error":
+            self.bm.stop_socket(self.user_socket_conn_key)
+            self.user_socket_conn_key = self._start_user_socket()
+            self.cache.balances.clear()
+            return
+        if msg["e"] == "outboundAccountPosition":
+            for bal in msg["B"]:
+                self.cache.balances[bal["a"]] = float(bal["f"])
+        elif msg["e"] == "balanceUpdate":
+            del self.cache.balances[msg["a"]]
+
+    def close(self):
+        self.bm.close()
+        reactor.stop()

--- a/binance_trade_bot/binance_stream_manager.py
+++ b/binance_trade_bot/binance_stream_manager.py
@@ -1,5 +1,5 @@
 import time
-from typing import Dict
+from typing import Dict, Set
 
 from autobahn.twisted.websocket import connectWS
 from binance.client import Client
@@ -33,6 +33,7 @@ class CustomBinanceSocketManager(BinanceSocketManager):
 class BinanceCache:  # pylint: disable=too-few-public-methods
     ticker_values: Dict[str, float] = {}
     balances: Dict[str, float] = {}
+    non_existent_tickers: Set[str] = set()
 
 
 class BinanceStreamManager:

--- a/binance_trade_bot/crypto_trading.py
+++ b/binance_trade_bot/crypto_trading.py
@@ -36,7 +36,9 @@ def main():
     schedule.every(1).minutes.do(trader.update_values).tag("updating value history")
     schedule.every(1).minutes.do(db.prune_scout_history).tag("pruning scout history")
     schedule.every(1).hours.do(db.prune_value_history).tag("pruning value history")
-
-    while True:
-        schedule.run_pending()
-        time.sleep(1)
+    try:
+        while True:
+            schedule.run_pending()
+            time.sleep(1)
+    finally:
+        manager.stream_manager.close()

--- a/binance_trade_bot/database.py
+++ b/binance_trade_bot/database.py
@@ -19,7 +19,7 @@ class Database:
     def __init__(self, logger: Logger, config: Config, uri="sqlite:///data/crypto_trading.db"):
         self.logger = logger
         self.config = config
-        self.engine = create_engine(uri, connect_args={"check_same_thread": False})
+        self.engine = create_engine(uri)
         self.SessionMaker = sessionmaker(bind=self.engine)
         self.socketio_client = Client()
 

--- a/binance_trade_bot/database.py
+++ b/binance_trade_bot/database.py
@@ -19,7 +19,7 @@ class Database:
     def __init__(self, logger: Logger, config: Config, uri="sqlite:///data/crypto_trading.db"):
         self.logger = logger
         self.config = config
-        self.engine = create_engine(uri)
+        self.engine = create_engine(uri, connect_args={"check_same_thread": False})
         self.SessionMaker = sessionmaker(bind=self.engine)
         self.socketio_client = Client()
 

--- a/binance_trade_bot/logger.py
+++ b/binance_trade_bot/logger.py
@@ -21,7 +21,7 @@ class Logger:
 
         # logging to console
         ch = logging.StreamHandler()
-        ch.setLevel(logging.DEBUG)
+        ch.setLevel(logging.INFO)
         ch.setFormatter(formatter)
         self.Logger.addHandler(ch)
 
@@ -51,5 +51,5 @@ class Logger:
     def error(self, message, notification=True):
         self.log(message, "error", notification)
 
-    def debug(self, message, notification=True):
+    def debug(self, message, notification=False):
         self.log(message, "debug", notification)

--- a/binance_trade_bot/strategies/default_strategy.py
+++ b/binance_trade_bot/strategies/default_strategy.py
@@ -14,8 +14,6 @@ class Strategy(AutoTrader):
         """
         Scout for potential jumps from the current coin to another coin
         """
-        all_tickers = self.manager.get_all_market_tickers()
-
         current_coin = self.db.get_current_coin()
         # Display on the console, the current coin+Bridge, so users can see *some* activity and not think the bot has
         # stopped. Not logging though to reduce log size.
@@ -25,13 +23,13 @@ class Strategy(AutoTrader):
             end="\r",
         )
 
-        current_coin_price = all_tickers.get_price(current_coin + self.config.BRIDGE)
+        current_coin_price = self.manager.get_ticker_price(current_coin + self.config.BRIDGE)
 
         if current_coin_price is None:
             self.logger.info("Skipping scouting... current coin {} not found".format(current_coin + self.config.BRIDGE))
             return
 
-        self._jump_to_best_coin(current_coin, current_coin_price, all_tickers)
+        self._jump_to_best_coin(current_coin, current_coin_price)
 
     def bridge_scout(self):
         current_coin = self.db.get_current_coin()
@@ -63,6 +61,5 @@ class Strategy(AutoTrader):
             if self.config.CURRENT_COIN_SYMBOL == "":
                 current_coin = self.db.get_current_coin()
                 self.logger.info(f"Purchasing {current_coin} to begin trading")
-                all_tickers = self.manager.get_all_market_tickers()
-                self.manager.buy_alt(current_coin, self.config.BRIDGE, all_tickers)
+                self.manager.buy_alt(current_coin, self.config.BRIDGE)
                 self.logger.info("Ready to start trading")

--- a/binance_trade_bot/strategies/multiple_coins_strategy.py
+++ b/binance_trade_bot/strategies/multiple_coins_strategy.py
@@ -8,7 +8,6 @@ class Strategy(AutoTrader):
         """
         Scout for potential jumps from the current coin to another coin
         """
-        all_tickers = self.manager.get_all_market_tickers()
         have_coin = False
 
         # last coin bought
@@ -20,7 +19,7 @@ class Strategy(AutoTrader):
 
         for coin in self.db.get_coins():
             current_coin_balance = self.manager.get_currency_balance(coin.symbol)
-            coin_price = all_tickers.get_price(coin + self.config.BRIDGE)
+            coin_price = self.manager.get_ticker_price(coin + self.config.BRIDGE)
 
             if coin_price is None:
                 self.logger.info("Skipping scouting... current coin {} not found".format(coin + self.config.BRIDGE))
@@ -41,7 +40,7 @@ class Strategy(AutoTrader):
                 end="\r",
             )
 
-            self._jump_to_best_coin(coin, coin_price, all_tickers)
+            self._jump_to_best_coin(coin, coin_price)
 
         if not have_coin:
             self.bridge_scout()

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ eventlet==0.30.2
 python-socketio[client]==5.0.4
 cachetools==4.2.1
 sqlitedict==1.7.0
+twisted==21.2.0


### PR DESCRIPTION
This PR supersedes @j-waters ' pull request. Backtest support is also added by mocking ```BinanceOrder``` class. Credits mostly goes to @ryansonshine and @j-waters for the implementation. 

The goal of this PR is to reduce API calls that goes to Binance which is targeted to reduce the API call issues that are currently happening. Quoting from @j-waters : 

*A cache of the current ticker prices and the user's current balance are now stored in the* BinanceApiManager. *This cache is updated live by two websocket connections.*

*Eventually we'll also be able to use this to wait for trades to complete.*

*In the event of the socket disconnecting, it will attempt to reconnect. I had to extend the python-binance library a bit to make sure that was working. If it can reconnect, it will clear the caches to make sure new data is fetched, just in case a socket event was missed. If it can't, currently the bot will just continue running without the sockets. Since ticker prices will never update, the bot won't buy anything, so this won't do too much damage. I'll think of how to best handle this, any ideas would be appreciated.*

*This massively reduces the number of API calls we have to make, and makes scouting so much faster. The get_fees method also runs instantly now.*


