### PR TITLE
Verify Binance Config on Startup via API Call

### DIFF
--- a/binance_trade_bot/binance_api_manager.py
+++ b/binance_trade_bot/binance_api_manager.py
@@ -23,6 +23,7 @@ class AllTickers:  # pylint: disable=too-few-public-methods
 
 class BinanceAPIManager:
     def __init__(self, config: Config, db: Database, logger: Logger):
+        # initializing the client class calls `ping` API endpoint, verifying the connection
         self.binance_client = Client(
             config.BINANCE_API_KEY,
             config.BINANCE_API_SECRET_KEY,
@@ -62,6 +63,12 @@ class BinanceAPIManager:
         if bnb_balance >= fee_amount_bnb:
             return base_fee * 0.75
         return base_fee
+
+    def get_account(self):
+        """
+        Get account information
+        """
+        return self.binance_client.get_account()
 
     def get_all_market_tickers(self) -> AllTickers:
         """

--- a/binance_trade_bot/crypto_trading.py
+++ b/binance_trade_bot/crypto_trading.py
@@ -16,6 +16,13 @@ def main():
     config = Config()
     db = Database(logger, config)
     manager = BinanceAPIManager(config, db, logger)
+    # check if we can access API feature that require valid config
+    try:
+        _ = manager.get_account()
+    except Exception as e:  # pylint: disable=broad-except
+        logger.error("Couldn't access Binance API - API keys may be wrong or lack sufficient permissions")
+        logger.error(e)
+        return
     strategy = get_strategy(config.STRATEGY)
     if strategy is None:
         logger.error("Invalid strategy name")


### PR DESCRIPTION
Following some issues reporting an error in `get_trade_fees`, @j-waters realized this error might actually stem from invalid configuration (bad API keys for example). The API call in `get_trade_fees` is the first one that can fail due to this, since the other API call (automatically made when the `python-binance` client is initialized) is to a ping endpoint, which doesn't require any valid config to succeed.

**CHANGES**
- Added to `get_account` method to `binance_api_manager.py`
- Invoking `get_account` on startup (`crypto_trading.py`) and exiting with a meaningful message on exceptions
- Added a comment in the constructor of `BinanceAPIManager` mentioning the implicit ping API call