### PR TITLE
Avoid sqlitebrowser exposure by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,5 +39,3 @@ services:
     volumes:
       - ./data/config:/config
       - ./data:/data
-    ports:
-      - 3000:3000


### PR DESCRIPTION
We don't want a service that exposes confidential data on a network port by default.