### PR TITLE
Correcting the trading fees for the backtest

### DIFF
--- a/binance_trade_bot/backtest.py
+++ b/binance_trade_bot/backtest.py
@@ -46,7 +46,7 @@ class MockBinanceManager(BinanceAPIManager):
         return FakeAllTickers(self)
 
     def get_fee(self, origin_coin: Coin, target_coin: Coin, selling: bool):
-        return 0.0075
+        return 0.00075
 
     def get_market_ticker_price(self, ticker_symbol: str):
         """


### PR DESCRIPTION
The fees for the backtest are 10 times bigger than the real ones
https://www.binance.com/en/fee/schedule