### PR TITLE
Use rustc from apt in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,7 @@ WORKDIR /install
 
 COPY requirements.txt /requirements.txt
 
-RUN apt-get update && apt-get install -y curl && \
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
-    . /root/.cargo/env && \
-    rustup toolchain install 1.41.0 && \
+RUN apt-get update && apt-get install -y rustc && \
     pip install --prefix=/install -r /requirements.txt
 
 FROM python:3.8-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM --platform=$BUILDPLATFORM python:3.8 as builder
 
 WORKDIR /install
 
-COPY requirements.txt /requirements.txt
+RUN apt-get update && apt-get install -y rustc
 
-RUN apt-get update && apt-get install -y rustc && \
-    pip install --prefix=/install -r /requirements.txt
+COPY requirements.txt /requirements.txt
+RUN pip install --prefix=/install -r /requirements.txt
 
 FROM python:3.8-slim
 


### PR DESCRIPTION
Speed up initial Docker builds a little.

The `rustc` package in `python:3.8`  (which is Debian Buster) provides a Rust version recent enough to build `cryptography` when needed (i.e, ARM).

Slight re-ordering here to install requirements here after installing apt, meaning you can change requirements without incurring the penalty of fetching apt again!