### PR TITLE
fix: avoid being stuck on bridge if buy order fails

### DIFF
--- a/binance_trade_bot/auto_trader.py
+++ b/binance_trade_bot/auto_trader.py
@@ -16,6 +16,7 @@ class AutoTrader:
         self.db = database
         self.logger = logger
         self.config = config
+        self.failed_buy_order = False
 
     def initialize(self):
         self.initialize_trade_thresholds()
@@ -42,9 +43,11 @@ class AutoTrader:
         if result is not None:
             self.db.set_current_coin(pair.to_coin)
             self.update_trade_threshold(pair.to_coin, float(result["price"]), all_tickers)
+            self.failed_buy_order = False
             return result
 
         self.logger.info("Couldn't buy, going back to scouting mode...")
+        self.failed_buy_order = True
         return None
 
     def update_trade_threshold(self, coin: Coin, coin_price: float, all_tickers: AllTickers):
@@ -166,7 +169,11 @@ class AutoTrader:
                 # There will only be one coin where all the ratios are negative. When we find it, buy it if we can
                 if bridge_balance > self.manager.get_min_notional(coin.symbol, self.config.BRIDGE.symbol):
                     self.logger.info(f"Will be purchasing {coin} using bridge coin")
-                    self.manager.buy_alt(coin, self.config.BRIDGE, all_tickers)
+                    result = self.manager.buy_alt(coin, self.config.BRIDGE, all_tickers)
+                    if result == None:
+                        self.failed_buy_order = True
+                    else:
+                        self.failed_buy_order = False
                     return coin
         return None
 

--- a/binance_trade_bot/auto_trader.py
+++ b/binance_trade_bot/auto_trader.py
@@ -170,7 +170,7 @@ class AutoTrader:
                 if bridge_balance > self.manager.get_min_notional(coin.symbol, self.config.BRIDGE.symbol):
                     self.logger.info(f"Will be purchasing {coin} using bridge coin")
                     result = self.manager.buy_alt(coin, self.config.BRIDGE, all_tickers)
-                    if result == None:
+                    if result is None:
                         self.failed_buy_order = True
                     else:
                         self.failed_buy_order = False

--- a/binance_trade_bot/strategies/default_strategy.py
+++ b/binance_trade_bot/strategies/default_strategy.py
@@ -11,6 +11,10 @@ class Strategy(AutoTrader):
         self.initialize_current_coin()
 
     def scout(self):
+        # check if previous buy order failed. If so, bridge scout for a new coin.
+        if(self.failed_buy_order):
+            self.bridge_scout()
+
         """
         Scout for potential jumps from the current coin to another coin
         """

--- a/binance_trade_bot/strategies/default_strategy.py
+++ b/binance_trade_bot/strategies/default_strategy.py
@@ -12,7 +12,7 @@ class Strategy(AutoTrader):
 
     def scout(self):
         # check if previous buy order failed. If so, bridge scout for a new coin.
-        if(self.failed_buy_order):
+        if self.failed_buy_order:
             self.bridge_scout()
 
         """

--- a/binance_trade_bot/strategies/default_strategy.py
+++ b/binance_trade_bot/strategies/default_strategy.py
@@ -11,13 +11,13 @@ class Strategy(AutoTrader):
         self.initialize_current_coin()
 
     def scout(self):
+        """
+        Scout for potential jumps from the current coin to another coin
+        """
         # check if previous buy order failed. If so, bridge scout for a new coin.
         if self.failed_buy_order:
             self.bridge_scout()
 
-        """
-        Scout for potential jumps from the current coin to another coin
-        """
         all_tickers = self.manager.get_all_market_tickers()
 
         current_coin = self.db.get_current_coin()

--- a/binance_trade_bot/strategies/multiple_coins_strategy.py
+++ b/binance_trade_bot/strategies/multiple_coins_strategy.py
@@ -11,13 +11,6 @@ class Strategy(AutoTrader):
         all_tickers = self.manager.get_all_market_tickers()
         have_coin = False
 
-        # last coin bought
-        current_coin = self.db.get_current_coin()
-        current_coin_symbol = ""
-
-        if current_coin is not None:
-            current_coin_symbol = current_coin.symbol
-
         for coin in self.db.get_coins():
             current_coin_balance = self.manager.get_currency_balance(coin.symbol)
             coin_price = all_tickers.get_price(coin + self.config.BRIDGE)
@@ -37,7 +30,7 @@ class Strategy(AutoTrader):
             # has stopped. Not logging though to reduce log size.
             print(
                 f"{datetime.now()} - CONSOLE - INFO - I am scouting the best trades. "
-                f"Current coin: {current_coin + self.config.BRIDGE} ",
+                f"Current coin: {coin + self.config.BRIDGE} ",
                 end="\r",
             )
 

--- a/binance_trade_bot/strategies/multiple_coins_strategy.py
+++ b/binance_trade_bot/strategies/multiple_coins_strategy.py
@@ -28,7 +28,7 @@ class Strategy(AutoTrader):
 
             min_notional = self.manager.get_min_notional(coin.symbol, self.config.BRIDGE.symbol)
 
-            if coin.symbol != current_coin_symbol and coin_price * current_coin_balance < min_notional:
+            if coin_price * current_coin_balance < min_notional:
                 continue
 
             have_coin = True


### PR DESCRIPTION
Hi,
this should fix #294.

The basic idea is that we cache if a buy order failed.
If so, we run the bridge scout method to avoid being stuck on the bridge.

Being stuck on the bridge can really be a serious issue when the market goes bullish.

I modified the backtest api manager to simulate failed buy orders here, so it can be tested:
https://github.com/tntwist/binance-trade-bot/tree/test-failed-buy

Greetings