### PR TITLE
Use scoped_session() correctly, preventing the generation of many sessions.

### DIFF
--- a/binance_trade_bot/database.py
+++ b/binance_trade_bot/database.py
@@ -20,7 +20,8 @@ class Database:
         self.logger = logger
         self.config = config
         self.engine = create_engine(uri)
-        self.SessionMaker = sessionmaker(bind=self.engine)
+        self.session_maker = sessionmaker(bind=self.engine)
+        self.scoped_session_factory = scoped_session(self.session_maker)
         self.socketio_client = Client()
 
     def socketio_connect(self):
@@ -38,9 +39,10 @@ class Database:
     @contextmanager
     def db_session(self):
         """
-        Creates a context with an open SQLAlchemy session.
+        Return the thread-local SQLAclhemy session in a context, committing and
+        closing when finished.
         """
-        session: Session = scoped_session(self.SessionMaker)
+        session: Session = self.scoped_session_factory()
         yield session
         session.commit()
         session.close()


### PR DESCRIPTION
I've been experimenting with using PostgreSQL as the database for this. It seems that resources are currently not disposed of correctly and will continue to hold connections indefinitely. This isn't a problem with SQLite which doesn't rely on connection pools.

As per the [SQLAlchemy docs on threading](https://docs.sqlalchemy.org/en/13/orm/contextual.html#unitofwork-contextual), `scoped_session` is used to create a factory/registry with returns the shared session. Calling `scoped_session` every time we attempt to grab a session means we get a new one every single time!

This fixes that --- now the shared one really is returned.