### PR TITLE
Backtesting Speedup: workaround for python-binance==0.7.11 bug that means price fetch limits are ignored

### DIFF
--- a/binance_trade_bot/backtest.py
+++ b/binance_trade_bot/backtest.py
@@ -61,7 +61,10 @@ class MockBinanceManager(BinanceAPIManager):
                 end_date = datetime.now()
             end_date = end_date.strftime("%d %b %Y %H:%M:%S")
             self.logger.info(f"Fetching prices for {ticker_symbol} between {self.datetime} and {end_date}")
-            for result in self.binance_client.get_historical_klines(
+
+            # _historical_klines must be used as get_historical_klines has
+            # bugged args (ignores end_date and limit) on python-binance==0.7.11
+            for result in self.binance_client._historical_klines(  # pylint: disable=no-member, protected-access
                 ticker_symbol, "1m", target_date, end_date, limit=1000
             ):
                 date = datetime.utcfromtimestamp(result[0] / 1000).strftime("%d %b %Y %H:%M:%S")


### PR DESCRIPTION
We call `get_historical_klines` to fetch old ticker prices in the back testing module, which involves passing in a target symbol, etc. but more importantly a begin date, an end date, and a count limit. 

Unfortunately, the library just ignores this.

https://github.com/sammchardy/python-binance/blob/0.7.11/binance/client.py#L873

```python
def get_historical_klines(self, symbol, interval, start_str, end_str=None, limit=500, spot=True)
    # ...
    return self._historical_klines(symbol, interval, start_str, end_str=None, limit=500, spot=True)
```

Fortunately, we can just call `_historical_klines` ourselves directly to workaround the problem. This gives a huge speed boost when fetching.