### PR TITLE
Fix: bug with unconditional 1s thread sleep in retry

### DIFF
--- a/binance_trade_bot/binance_api_manager.py
+++ b/binance_trade_bot/binance_api_manager.py
@@ -119,16 +119,14 @@ class BinanceAPIManager:
             return balance
 
     def retry(self, func, *args, **kwargs):
-        time.sleep(1)
-        attempts = 0
-        while attempts < 20:
+        for attempt in range(20):
             try:
                 return func(*args, **kwargs)
             except Exception:  # pylint: disable=broad-except
-                self.logger.warning(f"Failed to Buy/Sell. Trying Again (attempt {attempts}/20)")
-                if attempts == 0:
+                self.logger.warning(f"Failed to Buy/Sell. Trying Again (attempt {attempt}/20)")
+                if attempt == 0:
                     self.logger.warning(traceback.format_exc())
-                attempts += 1
+            time.sleep(1)
         return None
 
     def get_symbol_filter(self, origin_symbol: str, target_symbol: str, filter_type: str):


### PR DESCRIPTION
Current retry implementation sleeps for 1 second before making any attempt and then does each attempt without any pauses. This behavior contradicts with common sense and leads to issues - prices can change within that unconditional 1 second sleep compared to ones used in ratios calculation, if there was some server API error we don't let it resolve itself by simply waiting. So in this fix I changed retry to what I think original author intended to do.