### PR TITLE
Upgrade python-binance to 1.0.12 and pylint to 2.8.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,8 +55,8 @@ repos:
     files: ^(dev-)?requirements\.txt$
     args: [requirements.txt, dev-requirements.txt]
 
-- repo: https://github.com/pre-commit/mirrors-pylint
-  rev: v2.4.4
+- repo: https://github.com/pycqa/pylint
+  rev: v2.8.3
   hooks:
   - id: pylint
     name: PyLint
@@ -70,7 +70,7 @@ repos:
     - flask-socketio==5.0.1
     - gunicorn==20.1.0
     - pylint-sqlalchemy
-    - python-binance==0.7.11
+    - python-binance==1.0.12
     - python-socketio[client]==5.2.1
     - schedule==1.1.0
     - sqlalchemy==1.3.23

--- a/binance_trade_bot/binance_api_manager.py
+++ b/binance_trade_bot/binance_api_manager.py
@@ -40,7 +40,7 @@ class BinanceAPIManager:
 
     @cached(cache=TTLCache(maxsize=1, ttl=43200))
     def get_trade_fees(self) -> Dict[str, float]:
-        return {ticker["symbol"]: ticker["taker"] for ticker in self.binance_client.get_trade_fee()["tradeFee"]}
+        return {ticker["symbol"]: float(ticker["takerCommission"]) for ticker in self.binance_client.get_trade_fee()}
 
     @cached(cache=TTLCache(maxsize=1, ttl=60))
     def get_using_bnb_for_fees(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python-binance==0.7.11
+python-binance==1.0.12
 sqlalchemy==1.3.23
 schedule==1.1.0
 apprise==0.9.2


### PR DESCRIPTION
Fresh python-binance fixed backtest slowdown issues, that were introduced in 0.7.11. They also switched from WAPI to SAPI, because WAPI is going to be disabled by binance soon (versions prior to 1.0.x used WAPI, for instance, to obtain trade fees). And they add async support that we may utilize later.

Pylint upgrade is necessary because 2.4.4 version has bugs with handling parametrized type hints like `typing.Optional`. Also https://github.com/pre-commit/mirrors-pylint is marked by author as deprecated, use direct pylint repo instead.