### PR TITLE
Upgrade sqlalchemy to 1.4.15

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,7 +73,7 @@ repos:
     - python-binance==0.7.11
     - python-socketio[client]==5.2.1
     - schedule==1.1.0
-    - sqlalchemy==1.3.23
+    - sqlalchemy==1.4.15
     - sqlitedict==1.7.0
     - unicorn-binance-websocket-api==1.30.0
     - unicorn-fy==0.11.0

--- a/binance_trade_bot/models/pair.py
+++ b/binance_trade_bot/models/pair.py
@@ -22,6 +22,7 @@ class Pair(Base):
         select([func.count(Coin.symbol) == 2])
         .where(or_(Coin.symbol == from_coin_id, Coin.symbol == to_coin_id))
         .where(Coin.enabled.is_(True))
+        .scalar_subquery()
     )
 
     def __init__(self, from_coin: Coin, to_coin: Coin, ratio=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-binance==0.7.11
-sqlalchemy==1.3.23
+sqlalchemy==1.4.15
 schedule==1.1.0
 apprise==0.9.2
 Flask==1.1.2


### PR DESCRIPTION
Needed for #371.

Mainly 1.4 lets use use 2.0 style statements, where you can create expressions and statements without being tied to a session. Much more flexible.