### PR TITLE
Fix 235: KeyError: 'code' when calling US API

### DIFF
--- a/binance_trade_bot/auto_trader.py
+++ b/binance_trade_bot/auto_trader.py
@@ -123,10 +123,16 @@ class AutoTrader:
             # Obtain (current coin)/(optional coin)
             coin_opt_coin_ratio = coin_price / optional_coin_price
 
-            transaction_fee = self.manager.get_fee(pair.from_coin, self.config.BRIDGE, True) + self.manager.get_fee(
-                pair.to_coin, self.config.BRIDGE, False
-            )
 
+            transaction_fee = 0.001
+            
+            try:
+                transaction_fee = self.manager.get_fee(pair.from_coin, self.config.BRIDGE, True) + self.manager.get_fee(
+                    pair.to_coin, self.config.BRIDGE, False
+                )
+            catch:
+                pass
+            
             ratio_dict[pair] = (
                 coin_opt_coin_ratio - transaction_fee * self.config.SCOUT_MULTIPLIER * coin_opt_coin_ratio
             ) - pair.ratio


### PR DESCRIPTION
https://github.com/edeng23/binance-trade-bot/issues/235