### PR TITLE
Force to not use scientific notation on sending 'pricing' to the Binance API

### DIFF
--- a/binance_trade_bot/binance_api_manager.py
+++ b/binance_trade_bot/binance_api_manager.py
@@ -327,7 +327,7 @@ class BinanceAPIManager:
         while order is None:
             # Should sell at calculated price to avoid lost coin
             order = self.binance_client.order_limit_sell(
-                symbol=origin_symbol + target_symbol, quantity=order_quantity, price=from_coin_price
+                symbol=origin_symbol + target_symbol, quantity=order_quantity, price=f"{from_coin_price:8f}"
             )
 
         self.logger.info("order")


### PR DESCRIPTION
fix #437 

Force the bot to not use scientific notation on pricing, this is the cause of the error returned from API:

`APIError(code=-1100): Illegal characters found in parameter 'price'; legal range is '^([0-9]{1,20})(\.[0-9]{1,20})?$'.`