### PR TITLE
 Fix unnecessary thread sleep bug in retry 

### DIFF
--- a/binance_trade_bot/binance_api_manager.py
+++ b/binance_trade_bot/binance_api_manager.py
@@ -119,16 +119,14 @@ class BinanceAPIManager:
             return balance
 
     def retry(self, func, *args, **kwargs):
-        time.sleep(1)
-        attempts = 0
-        while attempts < 20:
+        for attempt in range(20):
             try:
                 return func(*args, **kwargs)
             except Exception:  # pylint: disable=broad-except
-                self.logger.warning(f"Failed to Buy/Sell. Trying Again (attempt {attempts}/20)")
-                if attempts == 0:
+                self.logger.warning(f"Failed to Buy/Sell. Trying Again (attempt {attempt}/20)")
+                if attempt == 0:
                     self.logger.warning(traceback.format_exc())
-                attempts += 1
+                time.sleep(1)
         return None
 
     def get_symbol_filter(self, origin_symbol: str, target_symbol: str, filter_type: str):


### PR DESCRIPTION
Apparently originaly intended to sleep for 1s after each attempt, but instead we slept unconditionally for 1s before making an order and did each attempt without further waiting. This should resolve some issues with 'sell price become lower' frequent messages.