### PR TITLE
Fix/Hardcoded fee in case of TLD=us

### DIFF
--- a/binance_trade_bot/binance_api_manager.py
+++ b/binance_trade_bot/binance_api_manager.py
@@ -47,6 +47,8 @@ class BinanceAPIManager:
         return self.binance_client.get_bnb_burn_spot_margin()["spotBNBBurn"]
 
     def get_fee(self, origin_coin: Coin, target_coin: Coin, selling: bool):
+        if self.config.BINANCE_TLD != "com":
+            return float(0.001)
         base_fee = self.get_trade_fees()[origin_coin + target_coin]
         if not self.get_using_bnb_for_fees():
             return base_fee

--- a/binance_trade_bot/binance_api_manager.py
+++ b/binance_trade_bot/binance_api_manager.py
@@ -49,7 +49,6 @@ class BinanceAPIManager:
     def get_fee(self, origin_coin: Coin, target_coin: Coin, selling: bool):
         if self.config.BINANCE_TLD != "com":
             return float(0.001)
-        
         base_fee = self.get_trade_fees()[origin_coin + target_coin]
         if not self.get_using_bnb_for_fees():
             return base_fee

--- a/binance_trade_bot/binance_api_manager.py
+++ b/binance_trade_bot/binance_api_manager.py
@@ -47,6 +47,9 @@ class BinanceAPIManager:
         return self.binance_client.get_bnb_burn_spot_margin()["spotBNBBurn"]
 
     def get_fee(self, origin_coin: Coin, target_coin: Coin, selling: bool):
+        if self.config.BINANCE_TLD != "com":
+            return float(0.001)
+        
         base_fee = self.get_trade_fees()[origin_coin + target_coin]
         if not self.get_using_bnb_for_fees():
             return base_fee


### PR DESCRIPTION
Binance.us doesn't have a a API call for the fee. So it needs to be hardcoded 
It should solve this issue #397 