### PR TITLE
Adding itsdangerous to the requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ cachetools==4.2.2
 sqlitedict==1.7.0
 unicorn-binance-websocket-api==1.34.2
 unicorn-fy==0.11.0
+itsdangerous==2.0.1


### PR DESCRIPTION
Flask needs itsdangerous as requirements but in itsdangerous>=2.1 the API is deprecated. So we need at most 2.0.1