### PR TITLE
Added itsdangerous==2.0.1 as requirement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,6 +69,7 @@ repos:
     - flask-cors==3.0.10
     - flask-socketio==5.0.1
     - gunicorn==20.1.0
+    - itsdangerous==2.0.1
     - pylint-sqlalchemy
     - python-binance==1.0.12
     - python-socketio[client]==5.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ cachetools==4.2.2
 sqlitedict==1.7.0
 unicorn-binance-websocket-api==1.34.2
 unicorn-fy==0.11.0
+itsdangerous==2.0.1


### PR DESCRIPTION
Flask 1.1.2 is set up to require itsdangerous >= 0.24. The latest released (itsdangerous) version (2.10) deprecated the json API. To continue using Flask 1.1.2, we need to require at most itdangerous 2.0.1 (not 2.10)