### PR TITLE
Fix Ticker does not exist: USDTUSDT , USDTBTC

### DIFF
--- a/binance_trade_bot/binance_api_manager.py
+++ b/binance_trade_bot/binance_api_manager.py
@@ -90,7 +90,7 @@ class BinanceAPIManager:
             }
             self.logger.debug(f"Fetched all ticker prices: {self.cache.ticker_values}")
             price = self.cache.ticker_values.get(ticker_symbol, None)
-            if price is None:
+            if price is None and ticker_symbol != 'USDTUSDT' and ticker_symbol != 'USDTBTC':
                 self.logger.info(f"Ticker does not exist: {ticker_symbol} - will not be fetched from now on")
                 self.cache.non_existent_tickers.add(ticker_symbol)
 


### PR DESCRIPTION
the following error messages have been resolved:
Ticker does not exist: USDTUSDT - will not be fetched from now on

Ticker does not exist: USDTBTC - will not be fetched from now on